### PR TITLE
fix: #1 add --mailbox flag to shared mailbox write operations

### DIFF
--- a/src/commands/mail.ts
+++ b/src/commands/mail.ts
@@ -56,6 +56,7 @@ export const mailCommand = new Command('mail')
   .option('--markdown', 'Parse message as markdown (bold, links, lists)')
   .option('--json', 'Output as JSON')
   .option('--token <token>', 'Use a specific token')
+  .option('--mailbox <email>', 'Shared mailbox for reply/forward (routes via X-AnchorMailbox)')
   .action(async (folder: string, options: {
     limit: string;
     page: string;
@@ -81,6 +82,7 @@ export const mailCommand = new Command('mail')
     json?: boolean;
     token?: string;
     draft?: boolean;
+    mailbox?: string;
   }) => {
     const authResult = await resolveAuth({
       token: options.token,
@@ -404,7 +406,8 @@ export const mailCommand = new Command('mail')
           id,
           message,
           isReplyAll,
-          isHtml
+          isHtml,
+          options.mailbox
         );
 
         if (!result.ok || !result.data) {
@@ -422,7 +425,8 @@ export const mailCommand = new Command('mail')
         id,
         message,
         isReplyAll,
-        isHtml
+        isHtml,
+        options.mailbox
       );
 
       if (!result.ok) {
@@ -451,7 +455,8 @@ export const mailCommand = new Command('mail')
         authResult.token!,
         id,
         recipients,
-        options.message
+        options.message,
+        options.mailbox
       );
 
       if (!result.ok) {

--- a/src/commands/send.ts
+++ b/src/commands/send.ts
@@ -18,6 +18,7 @@ export const sendCommand = new Command('send')
   .option('--markdown', 'Parse body as markdown (bold, links, lists)')
   .option('--json', 'Output as JSON')
   .option('--token <token>', 'Use a specific token')
+  .option('--mailbox <email>', 'Send from shared mailbox (Send As)')
   .action(async (options: {
     to: string;
     subject: string;
@@ -29,6 +30,7 @@ export const sendCommand = new Command('send')
     markdown?: boolean;
     json?: boolean;
     token?: string;
+    mailbox?: string;
   }) => {
     const authResult = await resolveAuth({
       token: options.token,
@@ -114,6 +116,7 @@ export const sendCommand = new Command('send')
       body,
       bodyType,
       attachments,
+      mailbox: options.mailbox,
     });
 
     if (!result.ok) {

--- a/src/lib/ews-client.ts
+++ b/src/lib/ews-client.ts
@@ -93,14 +93,15 @@ function soapEnvelope(body: string): string {
 </soap:Envelope>`;
 }
 
-async function callEws(token: string, envelope: string): Promise<string> {
+async function callEws(token: string, envelope: string, mailbox?: string): Promise<string> {
+  const anchorMailbox = mailbox || EWS_USERNAME;
   const response = await fetch(EWS_ENDPOINT, {
     method: 'POST',
     headers: {
       'Authorization': `Bearer ${token}`,
       'Content-Type': 'text/xml; charset=utf-8',
       'Accept': 'text/xml',
-      'X-AnchorMailbox': EWS_USERNAME,
+      'X-AnchorMailbox': anchorMailbox,
     },
     body: envelope,
   });
@@ -1025,9 +1026,12 @@ export async function sendEmail(
     body: string;
     bodyType?: 'Text' | 'HTML';
     attachments?: EmailAttachment[];
+    mailbox?: string;
   }
 ): Promise<OwaResponse<void>> {
   try {
+    const { mailbox } = options;
+
     const toXml = options.to.map(e =>
       `<t:Mailbox><t:EmailAddress>${xmlEscape(e)}</t:EmailAddress></t:Mailbox>`
     ).join('');
@@ -1044,12 +1048,24 @@ export async function sendEmail(
 
     const bodyType = options.bodyType || 'Text';
 
+    // Build From element for shared mailbox (Send As)
+    const fromXml = mailbox
+      ? `<t:From><t:Mailbox><t:EmailAddress>${xmlEscape(mailbox)}</t:EmailAddress></t:Mailbox></t:From>`
+      : '';
+
+    // Build SavedItemFolderId targeting shared mailbox sentitems
+    const savedItemFolderIdXml = mailbox
+      ? `<m:SavedItemFolderId><t:DistinguishedFolderId Id="sentitems"><t:Mailbox><t:EmailAddress>${xmlEscape(mailbox)}</t:EmailAddress></t:Mailbox></t:DistinguishedFolderId></m:SavedItemFolderId>`
+      : '';
+
     // If no attachments, send directly
     if (!options.attachments || options.attachments.length === 0) {
       const envelope = soapEnvelope(`
       <m:CreateItem MessageDisposition="SendAndSaveCopy">
+        ${savedItemFolderIdXml}
         <m:Items>
           <t:Message>
+            ${fromXml}
             <t:Subject>${xmlEscape(options.subject)}</t:Subject>
             <t:Body BodyType="${bodyType}">${xmlEscape(options.body)}</t:Body>
             <t:ToRecipients>${toXml}</t:ToRecipients>
@@ -1058,7 +1074,7 @@ export async function sendEmail(
           </t:Message>
         </m:Items>
       </m:CreateItem>`);
-      await callEws(token, envelope);
+      await callEws(token, envelope, mailbox);
       return { ok: true, status: 200 };
     }
 
@@ -1088,7 +1104,8 @@ export async function replyToEmail(
   messageId: string,
   comment: string,
   replyAll: boolean = false,
-  isHtml: boolean = false
+  isHtml: boolean = false,
+  mailbox?: string
 ): Promise<OwaResponse<void>> {
   try {
     const tag = replyAll ? 'ReplyAllToItem' : 'ReplyToItem';
@@ -1104,7 +1121,7 @@ export async function replyToEmail(
       </m:Items>
     </m:CreateItem>`);
 
-    await callEws(token, envelope);
+    await callEws(token, envelope, mailbox);
     return { ok: true, status: 200 };
   } catch (err) {
     return ewsError(err);
@@ -1116,7 +1133,8 @@ export async function replyToEmailDraft(
   messageId: string,
   comment: string,
   replyAll: boolean = false,
-  isHtml: boolean = false
+  isHtml: boolean = false,
+  mailbox?: string
 ): Promise<OwaResponse<{ draftId: string }>> {
   try {
     const tag = replyAll ? 'ReplyAllToItem' : 'ReplyToItem';
@@ -1132,7 +1150,7 @@ export async function replyToEmailDraft(
       </m:Items>
     </m:CreateItem>`);
 
-    const xml = await callEws(token, envelope);
+    const xml = await callEws(token, envelope, mailbox);
     const draftId = extractAttribute(xml, 'ItemId', 'Id');
     return ewsResult({ draftId });
   } catch (err) {
@@ -1144,7 +1162,8 @@ export async function forwardEmail(
   token: string,
   messageId: string,
   toRecipients: string[],
-  comment?: string
+  comment?: string,
+  mailbox?: string
 ): Promise<OwaResponse<void>> {
   try {
     const toXml = toRecipients.map(e =>
@@ -1162,7 +1181,7 @@ export async function forwardEmail(
       </m:Items>
     </m:CreateItem>`);
 
-    await callEws(token, envelope);
+    await callEws(token, envelope, mailbox);
     return { ok: true, status: 200 };
   } catch (err) {
     return ewsError(err);


### PR DESCRIPTION
fix: #1 add --mailbox flag to shared mailbox write operations

Closes #1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how outbound EWS write operations are routed and authored (adds `From`/`SavedItemFolderId` and modifies `X-AnchorMailbox`), which can affect delivery and where sent items are stored for shared mailboxes.
> 
> **Overview**
> Adds a new `--mailbox` CLI flag to `send` and `mail` so users can **send as** / reply / forward from a shared mailbox.
> 
> Updates the EWS client to accept an optional mailbox for write operations: `callEws` now sets `X-AnchorMailbox` from the provided mailbox, and `sendEmail` additionally injects `From` and targets the shared mailbox `sentitems` via `SavedItemFolderId` when `mailbox` is set; reply/forward APIs plumb the mailbox through to `callEws`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb73a2d40669814aafe442eb98d84f7febeea7e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->