### PR TITLE
Revert "fix: #1 add --mailbox flag to shared mailbox write operations"

### DIFF
--- a/src/commands/mail.ts
+++ b/src/commands/mail.ts
@@ -56,7 +56,6 @@ export const mailCommand = new Command('mail')
   .option('--markdown', 'Parse message as markdown (bold, links, lists)')
   .option('--json', 'Output as JSON')
   .option('--token <token>', 'Use a specific token')
-  .option('--mailbox <email>', 'Shared mailbox for reply/forward (routes via X-AnchorMailbox)')
   .action(async (folder: string, options: {
     limit: string;
     page: string;
@@ -82,7 +81,6 @@ export const mailCommand = new Command('mail')
     json?: boolean;
     token?: string;
     draft?: boolean;
-    mailbox?: string;
   }) => {
     const authResult = await resolveAuth({
       token: options.token,
@@ -406,8 +404,7 @@ export const mailCommand = new Command('mail')
           id,
           message,
           isReplyAll,
-          isHtml,
-          options.mailbox
+          isHtml
         );
 
         if (!result.ok || !result.data) {
@@ -425,8 +422,7 @@ export const mailCommand = new Command('mail')
         id,
         message,
         isReplyAll,
-        isHtml,
-        options.mailbox
+        isHtml
       );
 
       if (!result.ok) {
@@ -455,8 +451,7 @@ export const mailCommand = new Command('mail')
         authResult.token!,
         id,
         recipients,
-        options.message,
-        options.mailbox
+        options.message
       );
 
       if (!result.ok) {

--- a/src/commands/send.ts
+++ b/src/commands/send.ts
@@ -18,7 +18,6 @@ export const sendCommand = new Command('send')
   .option('--markdown', 'Parse body as markdown (bold, links, lists)')
   .option('--json', 'Output as JSON')
   .option('--token <token>', 'Use a specific token')
-  .option('--mailbox <email>', 'Send from shared mailbox (Send As)')
   .action(async (options: {
     to: string;
     subject: string;
@@ -30,7 +29,6 @@ export const sendCommand = new Command('send')
     markdown?: boolean;
     json?: boolean;
     token?: string;
-    mailbox?: string;
   }) => {
     const authResult = await resolveAuth({
       token: options.token,
@@ -116,7 +114,6 @@ export const sendCommand = new Command('send')
       body,
       bodyType,
       attachments,
-      mailbox: options.mailbox,
     });
 
     if (!result.ok) {

--- a/src/lib/ews-client.ts
+++ b/src/lib/ews-client.ts
@@ -93,15 +93,14 @@ function soapEnvelope(body: string): string {
 </soap:Envelope>`;
 }
 
-async function callEws(token: string, envelope: string, mailbox?: string): Promise<string> {
-  const anchorMailbox = mailbox || EWS_USERNAME;
+async function callEws(token: string, envelope: string): Promise<string> {
   const response = await fetch(EWS_ENDPOINT, {
     method: 'POST',
     headers: {
       'Authorization': `Bearer ${token}`,
       'Content-Type': 'text/xml; charset=utf-8',
       'Accept': 'text/xml',
-      'X-AnchorMailbox': anchorMailbox,
+      'X-AnchorMailbox': EWS_USERNAME,
     },
     body: envelope,
   });
@@ -1026,12 +1025,9 @@ export async function sendEmail(
     body: string;
     bodyType?: 'Text' | 'HTML';
     attachments?: EmailAttachment[];
-    mailbox?: string;
   }
 ): Promise<OwaResponse<void>> {
   try {
-    const { mailbox } = options;
-
     const toXml = options.to.map(e =>
       `<t:Mailbox><t:EmailAddress>${xmlEscape(e)}</t:EmailAddress></t:Mailbox>`
     ).join('');
@@ -1048,24 +1044,12 @@ export async function sendEmail(
 
     const bodyType = options.bodyType || 'Text';
 
-    // Build From element for shared mailbox (Send As)
-    const fromXml = mailbox
-      ? `<t:From><t:Mailbox><t:EmailAddress>${xmlEscape(mailbox)}</t:EmailAddress></t:Mailbox></t:From>`
-      : '';
-
-    // Build SavedItemFolderId targeting shared mailbox sentitems
-    const savedItemFolderIdXml = mailbox
-      ? `<m:SavedItemFolderId><t:DistinguishedFolderId Id="sentitems"><t:Mailbox><t:EmailAddress>${xmlEscape(mailbox)}</t:EmailAddress></t:Mailbox></t:DistinguishedFolderId></m:SavedItemFolderId>`
-      : '';
-
     // If no attachments, send directly
     if (!options.attachments || options.attachments.length === 0) {
       const envelope = soapEnvelope(`
       <m:CreateItem MessageDisposition="SendAndSaveCopy">
-        ${savedItemFolderIdXml}
         <m:Items>
           <t:Message>
-            ${fromXml}
             <t:Subject>${xmlEscape(options.subject)}</t:Subject>
             <t:Body BodyType="${bodyType}">${xmlEscape(options.body)}</t:Body>
             <t:ToRecipients>${toXml}</t:ToRecipients>
@@ -1074,7 +1058,7 @@ export async function sendEmail(
           </t:Message>
         </m:Items>
       </m:CreateItem>`);
-      await callEws(token, envelope, mailbox);
+      await callEws(token, envelope);
       return { ok: true, status: 200 };
     }
 
@@ -1104,8 +1088,7 @@ export async function replyToEmail(
   messageId: string,
   comment: string,
   replyAll: boolean = false,
-  isHtml: boolean = false,
-  mailbox?: string
+  isHtml: boolean = false
 ): Promise<OwaResponse<void>> {
   try {
     const tag = replyAll ? 'ReplyAllToItem' : 'ReplyToItem';
@@ -1121,7 +1104,7 @@ export async function replyToEmail(
       </m:Items>
     </m:CreateItem>`);
 
-    await callEws(token, envelope, mailbox);
+    await callEws(token, envelope);
     return { ok: true, status: 200 };
   } catch (err) {
     return ewsError(err);
@@ -1133,8 +1116,7 @@ export async function replyToEmailDraft(
   messageId: string,
   comment: string,
   replyAll: boolean = false,
-  isHtml: boolean = false,
-  mailbox?: string
+  isHtml: boolean = false
 ): Promise<OwaResponse<{ draftId: string }>> {
   try {
     const tag = replyAll ? 'ReplyAllToItem' : 'ReplyToItem';
@@ -1150,7 +1132,7 @@ export async function replyToEmailDraft(
       </m:Items>
     </m:CreateItem>`);
 
-    const xml = await callEws(token, envelope, mailbox);
+    const xml = await callEws(token, envelope);
     const draftId = extractAttribute(xml, 'ItemId', 'Id');
     return ewsResult({ draftId });
   } catch (err) {
@@ -1162,8 +1144,7 @@ export async function forwardEmail(
   token: string,
   messageId: string,
   toRecipients: string[],
-  comment?: string,
-  mailbox?: string
+  comment?: string
 ): Promise<OwaResponse<void>> {
   try {
     const toXml = toRecipients.map(e =>
@@ -1181,7 +1162,7 @@ export async function forwardEmail(
       </m:Items>
     </m:CreateItem>`);
 
-    await callEws(token, envelope, mailbox);
+    await callEws(token, envelope);
     return { ok: true, status: 200 };
   } catch (err) {
     return ewsError(err);


### PR DESCRIPTION
## Closing — superseded by ongoing PR work

This revert PR was opened to undo #8 (`--mailbox` flag for shared mailbox write operations), but it should be closed rather than merged.

**Why closing is the right call:**

1. **Conflicts with current main** — the branch is 20+ files behind and cannot be cleanly rebased. Resolving those conflicts would essentially be a full rewrite, not a revert.

2. **#8 is actively being built upon** — #9 (calendar write ops with `--mailbox`) depends on the same mailbox infrastructure that #8 introduced. Reverting #8 would break #9.

3. **P1 review flags on this PR** — Copilot/Codex reviewers correctly noted that reverting removes:
   - Shared mailbox X-AnchorMailbox routing (breaks reply/forward for shared mailboxes)
   - Shared mailbox Send-As support in `sendEmail`
   - Would leave docs referencing `--mailbox` for send/mail but the flag would be gone

4. **#13 doesn't supersede #8** — #13 fixes PR #7 (read-only mailbox support), not the write operations that #8 added.

**Path forward:** If write operations from shared mailboxes need to be scoped differently, that should be addressed in a forward-looking PR rather than reverting #8. The current approach in #9 and #13 builds on #8 rather than replacing it.

/cc @markus-lassfolk