### PR TITLE
fix: resolve pre-existing TS strict mode errors

### DIFF
--- a/src/commands/create-event.ts
+++ b/src/commands/create-event.ts
@@ -233,7 +233,7 @@ export const createEventCommand = new Command('create-event')
           }
 
           if (roomsResult.ok && roomsResult.data) {
-            const found = roomsResult.data.find((r) => r.Name.toLowerCase().includes(options.room?.toLowerCase()));
+            const found = roomsResult.data.find((r) => r.Name.toLowerCase().includes(options.room?.toLowerCase() ?? ''));
             if (found) {
               roomEmail = found.Address;
               roomName = found.Name;

--- a/src/commands/mail.ts
+++ b/src/commands/mail.ts
@@ -296,7 +296,7 @@ export const mailCommand = new Command('mail')
         const id = (options.markRead || options.markUnread)?.trim();
         const isRead = !!options.markRead;
 
-        const result = await updateEmail(authResult.token!, id, { IsRead: isRead });
+        const result = await updateEmail(authResult.token!, id ?? "", { IsRead: isRead });
 
         if (!result.ok) {
           console.error(`Error: ${result.error?.message || 'Failed to update email'}`);
@@ -324,7 +324,7 @@ export const mailCommand = new Command('mail')
           actionLabel = 'Unflagged';
         }
 
-        const result = await updateEmail(authResult.token!, id, {
+        const result = await updateEmail(authResult.token!, id ?? "", {
           Flag: { FlagStatus: flagStatus }
         });
 
@@ -418,7 +418,7 @@ export const mailCommand = new Command('mail')
         }
 
         if (options.draft) {
-          const result = await replyToEmailDraft(authResult.token!, id, message, isReplyAll, isHtml, options.mailbox);
+          const result = await replyToEmailDraft(authResult.token!, id ?? "", message, isReplyAll, isHtml, options.mailbox);
 
           if (!result.ok || !result.data) {
             console.error(`Error: ${result.error?.message || 'Failed to create reply draft'}`);
@@ -430,7 +430,7 @@ export const mailCommand = new Command('mail')
           return;
         }
 
-        const result = await replyToEmail(authResult.token!, id, message, isReplyAll, isHtml, options.mailbox);
+        const result = await replyToEmail(authResult.token!, id ?? "", message, isReplyAll, isHtml, options.mailbox);
 
         if (!result.ok) {
           console.error(`Error: ${result.error?.message || 'Failed to send reply'}`);
@@ -457,7 +457,7 @@ export const mailCommand = new Command('mail')
           .map((e) => e.trim())
           .filter(Boolean);
 
-        const result = await forwardEmail(authResult.token!, id, recipients, options.message, options.mailbox);
+        const result = await forwardEmail(authResult.token!, id ?? "", recipients ?? [], options.message ?? "", options.mailbox);
 
         if (!result.ok) {
           console.error(`Error: ${result.error?.message || 'Failed to forward email'}`);

--- a/src/commands/update-event.ts
+++ b/src/commands/update-event.ts
@@ -292,7 +292,7 @@ export const updateEventCommand = new Command('update-event')
           }
 
           if (roomsResult.ok && roomsResult.data) {
-            const found = roomsResult.data.find((r) => r.Name.toLowerCase().includes(options.room?.toLowerCase()));
+            const found = roomsResult.data.find((r) => r.Name.toLowerCase().includes(options.room?.toLowerCase() ?? ''));
             if (found) {
               roomEmail = found.Address;
               roomName = found.Name;


### PR DESCRIPTION
Fixes 6 pre-existing TypeScript strict mode errors where `string | undefined` was passed where `string` was expected. Also adds biome.json and CI workflow additions from the previous direct push attempt.\n\nCloses tracking this for CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-safety fixes; behavior only changes in edge cases where command options are unexpectedly `undefined` (now passing empty strings/arrays).
> 
> **Overview**
> Fixes several pre-existing TypeScript strict-mode errors in CLI commands by ensuring `string | undefined` values are coerced before calling EWS helpers.
> 
> Room-name matching in `create-event`/`update-event` now guards `options.room` when lowercasing, and `mail` operations (`updateEmail`, reply, forward) now pass fallback values (`""` / `[]`) where IDs, recipients, or message text could otherwise be `undefined`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f87353fd03dca3c5f499d4e8271d9d3d1b9e90c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->