### PR TITLE
fix: resolve TypeScript strict mode errors (string|undefined args)

### DIFF
--- a/src/commands/create-event.ts
+++ b/src/commands/create-event.ts
@@ -233,7 +233,9 @@ export const createEventCommand = new Command('create-event')
           }
 
           if (roomsResult.ok && roomsResult.data) {
-            const found = roomsResult.data.find((r) => r.Name.toLowerCase().includes(options.room?.toLowerCase() ?? ''));
+            const found = roomsResult.data.find((r) =>
+              options.room ? r.Name.toLowerCase().includes(options.room.toLowerCase()) : false
+            );
             if (found) {
               roomEmail = found.Address;
               roomName = found.Name;

--- a/src/commands/mail.ts
+++ b/src/commands/mail.ts
@@ -294,9 +294,13 @@ export const mailCommand = new Command('mail')
       // Handle mark as read/unread
       if (options.markRead || options.markUnread) {
         const id = (options.markRead || options.markUnread)?.trim();
+        if (!id) {
+          console.error('Error: --mark-read/--mark-unread requires a message ID');
+          process.exit(1);
+        }
         const isRead = !!options.markRead;
 
-        const result = await updateEmail(authResult.token!, id ?? "", { IsRead: isRead });
+        const result = await updateEmail(authResult.token!, id, { IsRead: isRead });
 
         if (!result.ok) {
           console.error(`Error: ${result.error?.message || 'Failed to update email'}`);
@@ -324,7 +328,11 @@ export const mailCommand = new Command('mail')
           actionLabel = 'Unflagged';
         }
 
-        const result = await updateEmail(authResult.token!, id ?? "", {
+        if (!id) {
+          console.error('Error: --flag/--unflag/--complete requires a message ID');
+          process.exit(1);
+        }
+        const result = await updateEmail(authResult.token!, id, {
           Flag: { FlagStatus: flagStatus }
         });
 
@@ -418,7 +426,11 @@ export const mailCommand = new Command('mail')
         }
 
         if (options.draft) {
-          const result = await replyToEmailDraft(authResult.token!, id ?? "", message, isReplyAll, isHtml, options.mailbox);
+          if (!id) {
+            console.error('Error: --reply/--reply-all requires a message ID');
+            process.exit(1);
+          }
+          const result = await replyToEmailDraft(authResult.token!, id, message, isReplyAll, isHtml, options.mailbox);
 
           if (!result.ok || !result.data) {
             console.error(`Error: ${result.error?.message || 'Failed to create reply draft'}`);
@@ -430,7 +442,11 @@ export const mailCommand = new Command('mail')
           return;
         }
 
-        const result = await replyToEmail(authResult.token!, id ?? "", message, isReplyAll, isHtml, options.mailbox);
+        if (!id) {
+          console.error('Error: --reply/--reply-all requires a message ID');
+          process.exit(1);
+        }
+        const result = await replyToEmail(authResult.token!, id, message, isReplyAll, isHtml, options.mailbox);
 
         if (!result.ok) {
           console.error(`Error: ${result.error?.message || 'Failed to send reply'}`);
@@ -457,7 +473,11 @@ export const mailCommand = new Command('mail')
           .map((e) => e.trim())
           .filter(Boolean);
 
-        const result = await forwardEmail(authResult.token!, id ?? "", recipients, options.message, options.mailbox);
+        if (!id) {
+          console.error('Error: --forward requires a message ID');
+          process.exit(1);
+        }
+        const result = await forwardEmail(authResult.token!, id, recipients, options.message, options.mailbox);
 
         if (!result.ok) {
           console.error(`Error: ${result.error?.message || 'Failed to forward email'}`);

--- a/src/commands/update-event.ts
+++ b/src/commands/update-event.ts
@@ -292,7 +292,9 @@ export const updateEventCommand = new Command('update-event')
           }
 
           if (roomsResult.ok && roomsResult.data) {
-            const found = roomsResult.data.find((r) => r.Name.toLowerCase().includes(options.room?.toLowerCase() ?? ''));
+            const found = roomsResult.data.find((r) =>
+              options.room ? r.Name.toLowerCase().includes(options.room.toLowerCase()) : false
+            );
             if (found) {
               roomEmail = found.Address;
               roomName = found.Name;


### PR DESCRIPTION
Required for all other PRs to pass CI typecheck.

Fixes 6 pre-existing TypeScript strict mode errors where `string | undefined` was passed where `string` was expected.

Marking all threads as resolved since these are pre-existing issues unrelated to the feature branches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-safety fixes that only change how potentially-undefined CLI inputs are coerced before calling API helpers. Main risk is masking a missing ID/room value by passing an empty string instead of failing earlier.
> 
> **Overview**
> Fixes TypeScript strict-mode issues by ensuring values passed to string-only APIs are always strings.
> 
> Updates `create-event`/`update-event` room name matching to handle missing `options.room` by defaulting the search substring to `''`, and updates `mail` actions (mark read/unread, flag/unflag/complete, reply/reply-all draft+send, forward) to pass `id ?? ""` into `updateEmail`/`replyToEmail*`/`forwardEmail`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71bcacb111fc449282b525daafb855cbd6f1460b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->