### PR TITLE
fix: reliable downloadFile with temp file, retry, and integrity check

### DIFF
--- a/src/lib/graph-client.ts
+++ b/src/lib/graph-client.ts
@@ -348,6 +348,8 @@ export async function downloadFile(
       if (contentLength !== null) {
         const expected = Number(contentLength);
         if (!Number.isFinite(expected)) {
+          await unlink(tmpPath).catch(() => {});
+          tmpPath = undefined;
           return graphError(`Download failed: invalid Content-Length header`);
         }
         if (bytesWritten !== expected) {


### PR DESCRIPTION
Closes #66

- Write to tmp/\{filename\}.\{random\}.tmp first, then atomic rename to final path
- Verify bytesWritten === Content-Length when header is present
- Retry up to 2 times on transient network errors (ECONNREFUSED, ETIMEDOUT, etc.)
- Clean up temp file on any error (network failure or size mismatch)
- streamWebToFile now returns bytesWritten for integrity verification
- Handle missing Content-Length header gracefully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the file download path to write/rename via temp files and adds retry + size validation logic, which could affect CLI/user workflows and filesystem behavior across platforms. Risk is limited to download functionality but touches error handling and disk writes.
> 
> **Overview**
> Improves `downloadFile` reliability by downloading into a per-download temp file (under a `tmp/` subdir) and then atomically `rename`-ing into place to avoid leaving partial/corrupt outputs.
> 
> Adds a small retry loop (up to 2 retries) for transient network/stream failures, cleans up temp artifacts on errors, and verifies downloaded size against `Content-Length` when present (with `streamWebToFile` now returning `bytesWritten` to support this check).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 526379aff67c0738ad34fc105119e71ceffc3eeb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->