### PR TITLE
fix(security): validate EWS_ENDPOINT and GRAPH_BASE_URL to prevent SSRF

### DIFF
--- a/src/lib/ews-client.ts
+++ b/src/lib/ews-client.ts
@@ -69,43 +69,7 @@ export function extractSelfClosingOrBlock(xml: string, tagName: string): string 
 
 // ─── SOAP Core ───
 
-/**
- * Validates a URL is safe for use as an API endpoint.
- * Blocks SSRF vectors: non-HTTPS protocols, localhost, link-local, and internal IPs.
- */
-function validateUrl(urlString: string, name: string): string {
-  let url: URL;
-  try {
-    url = new URL(urlString);
-  } catch {
-    throw new Error(`Invalid URL for ${name}: "${urlString}"`);
-  }
-
-  if (url.protocol !== 'https:') {
-    throw new Error(`${name} must use HTTPS, got: "${urlString}"`);
-  }
-
-  const hostname = url.hostname.toLowerCase();
-
-  // Block localhost variants
-  if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '[::1]') {
-    throw new Error(`${name} must not point to localhost: "${urlString}"`);
-  }
-
-  // Block bare IPv4 addresses — reject all IP literals to prevent internal network access
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { isIP } = require('node:net');
-  if (isIP(hostname)) {
-    throw new Error(`${name} must not be an IP address (use hostname): "${urlString}"`);
-  }
-
-  // Block cloud metadata endpoints (common SSRF target)
-  if (hostname === 'metadata.google.internal' || hostname.startsWith('169.254.')) {
-    throw new Error(`${name} must not point to link-local/metadata endpoint: "${urlString}"`);
-  }
-
-  return urlString;
-}
+import { validateUrl } from './url-validation';
 
 export const EWS_ENDPOINT = validateUrl(
   process.env.EWS_ENDPOINT || 'https://outlook.office365.com/EWS/Exchange.asmx',

--- a/src/lib/graph-constants.ts
+++ b/src/lib/graph-constants.ts
@@ -1,41 +1,4 @@
-/**
- * Validates a URL is safe for use as an API endpoint.
- * Blocks SSRF vectors: non-HTTPS protocols, localhost, link-local, and internal IPs.
- */
-function validateUrl(urlString: string, name: string): string {
-  let url: URL;
-  try {
-    url = new URL(urlString);
-  } catch {
-    throw new Error(`Invalid URL for ${name}: "${urlString}"`);
-  }
-
-  if (url.protocol !== 'https:') {
-    throw new Error(`${name} must use HTTPS, got: "${urlString}"`);
-  }
-
-  const hostname = url.hostname.toLowerCase();
-
-  // Block localhost variants
-  if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '[::1]') {
-    throw new Error(`${name} must not point to localhost: "${urlString}"`);
-  }
-
-  // Block bare IPv4 addresses (private/internal ranges are a subset of this)
-  // Use net.isIP to detect any IP literal — reject all IP addresses to prevent internal network access
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { isIP } = require('node:net');
-  if (isIP(hostname)) {
-    throw new Error(`${name} must not be an IP address (use hostname): "${urlString}"`);
-  }
-
-  // Block cloud metadata endpoints (common SSRF target)
-  if (hostname === 'metadata.google.internal' || hostname.startsWith('169.254.')) {
-    throw new Error(`${name} must not point to link-local/metadata endpoint: "${urlString}"`);
-  }
-
-  return urlString;
-}
+import { validateUrl } from './url-validation';
 
 export const GRAPH_BASE_URL = validateUrl(
   process.env.GRAPH_BASE_URL || 'https://graph.microsoft.com/v1.0',

--- a/src/lib/url-validation.ts
+++ b/src/lib/url-validation.ts
@@ -1,0 +1,41 @@
+/**
+ * Validates a URL is safe for use as an API endpoint.
+ * Blocks SSRF vectors: non-HTTPS protocols, localhost, link-local, and internal IPs.
+ */
+export function validateUrl(urlString: string, name: string): string {
+  let url: URL;
+  try {
+    url = new URL(urlString);
+  } catch {
+    throw new Error(`Invalid URL for ${name}: "${urlString}"`);
+  }
+
+  if (url.protocol !== 'https:') {
+    throw new Error(`${name} must use HTTPS, got: "${urlString}"`);
+  }
+
+  let hostname = url.hostname.toLowerCase();
+
+  // Strip brackets from IPv6 addresses before validation
+  // WHATWG URL returns IPv6 addresses with brackets (e.g., [::1]), but net.isIP expects bare IPs
+  hostname = hostname.replace(/^\[|\]$/g, '');
+
+  // Block localhost variants
+  if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1') {
+    throw new Error(`${name} must not point to localhost: "${urlString}"`);
+  }
+
+  // Block bare IPv4 addresses — reject all IP literals to prevent internal network access
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { isIP } = require('node:net');
+  if (isIP(hostname)) {
+    throw new Error(`${name} must not be an IP address (use hostname): "${urlString}"`);
+  }
+
+  // Block cloud metadata endpoints (common SSRF target)
+  if (hostname === 'metadata.google.internal' || hostname.startsWith('169.254.')) {
+    throw new Error(`${name} must not point to link-local/metadata endpoint: "${urlString}"`);
+  }
+
+  return urlString;
+}


### PR DESCRIPTION
## Summary

Add URL validation for  and  environment variables to prevent SSRF attacks.

## Changes

- Added  helper in both  and 
- Validation enforces:
  - **HTTPS required** — rejects , , etc.
  - **No localhost** — blocks , , 
  - **No IP addresses** — all IP literals rejected to prevent access to internal networks
  - **No link-local/metadata** — blocks  (cloud metadata) and 
- Uses built-in Node.js  and  parsing — **no new dependencies**

## Security Note

While these are not secrets, allowing arbitrary URLs to be configured via environment variables is a SSRF risk in deployment contexts. Validating at module load time fails fast and loudly rather than silently redirecting traffic.

Closes #69

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds strict URL validation at module load for `EWS_ENDPOINT` and `GRAPH_BASE_URL`, which can cause runtime startup failures in environments with nonconforming configuration. Change is security-focused but touches core network endpoint configuration used by EWS/Graph clients.
> 
> **Overview**
> **Hardens outbound Microsoft API endpoint configuration against SSRF.** `EWS_ENDPOINT` (in `ews-client.ts`) and `GRAPH_BASE_URL` (in `graph-constants.ts`) now run through a new `validateUrl` helper before being used.
> 
> `validateUrl` enforces *HTTPS-only* endpoints and rejects localhost, IP-literal hostnames, and common link-local/metadata targets, failing fast with clear errors when configuration is unsafe.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7344ada17390a0f9caab8173cdd59bb39c2a87c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->