### PR TITLE
fix(auth): validate JWT structure before caching to prevent opaque 401 errors

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,6 +15,18 @@ interface CachedToken {
   expiresAt: number;
 }
 
+/** Validate that a string is a well-formed JWT with three base64url parts. */
+function isValidJwtStructure(token: string): boolean {
+  const parts = token.split('.');
+  if (parts.length !== 3) return false;
+  try {
+    Buffer.from(parts[1], 'base64url').toString();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // Security model: cache file stores bearer/refresh tokens and must be owner-only.
 // Directory is created as 0700 and file writes enforce 0600 to satisfy least-privilege.
 // The cache path is anchored to a fixed, local per-user directory under homedir();
@@ -75,10 +87,22 @@ async function refreshAccessToken(clientId: string, refreshToken: string, tenant
     };
 
     if (response.ok && json.access_token) {
+      const accessToken = json.access_token;
+
+      // Refuse to cache tokens that are not well-formed JWTs
+      if (!isValidJwtStructure(accessToken)) {
+        throw new Error('OAuth server returned an invalid token structure — refusing to cache');
+      }
+
+      const expiresAt = getJwtExpiration(accessToken) ?? Date.now() + (json.expires_in || 3600) * 1000;
+      if (expiresAt <= Date.now()) {
+        throw new Error('OAuth server returned an already-expired token — refusing to cache');
+      }
+
       return {
-        accessToken: json.access_token,
+        accessToken,
         refreshToken: json.refresh_token || refreshToken,
-        expiresAt: getJwtExpiration(json.access_token) || Date.now() + (json.expires_in || 3600) * 1000
+        expiresAt
       };
     }
 
@@ -111,7 +135,12 @@ export async function resolveAuth(options?: { token?: string; identity?: string 
     // Check cached token
     const cached = await loadCachedToken(identity);
     if (cached && cached.expiresAt > Date.now() + 60_000) {
-      return { success: true, token: cached.accessToken };
+      // Guard against corrupted cache: validate JWT structure before returning
+      if (!isValidJwtStructure(cached.accessToken)) {
+        // Treat a malformed cached token as if there were no cache
+      } else {
+        return { success: true, token: cached.accessToken };
+      }
     }
 
     // Refresh - try cached refresh token first (may have been rotated), then .env

--- a/src/lib/graph-auth.ts
+++ b/src/lib/graph-auth.ts
@@ -15,6 +15,18 @@ interface CachedGraphToken {
   expiresAt: number;
 }
 
+/** Validate that a string is a well-formed JWT with three base64url parts. */
+function isValidJwtStructure(token: string): boolean {
+  const parts = token.split('.');
+  if (parts.length !== 3) return false;
+  try {
+    Buffer.from(parts[1], 'base64url').toString();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 const GRAPH_TOKEN_CACHE_FILE = join(homedir(), '.config', 'clippy', 'graph-token-cache.json');
 const GRAPH_SCOPES = [
   'https://graph.microsoft.com/Files.ReadWrite offline_access User.Read',
@@ -74,10 +86,22 @@ async function refreshGraphAccessToken(
     };
 
     if (response.ok && json.access_token) {
+      const accessToken = json.access_token;
+
+      // Refuse to cache tokens that are not well-formed JWTs
+      if (!isValidJwtStructure(accessToken)) {
+        throw new Error('OAuth server returned an invalid token structure — refusing to cache');
+      }
+
+      const expiresAt = getJwtExpiration(accessToken) ?? Date.now() + (json.expires_in || 3600) * 1000;
+      if (expiresAt <= Date.now()) {
+        throw new Error('OAuth server returned an already-expired token — refusing to cache');
+      }
+
       return {
-        accessToken: json.access_token,
+        accessToken,
         refreshToken: json.refresh_token || refreshToken,
-        expiresAt: getJwtExpiration(json.access_token) || Date.now() + (json.expires_in || 3600) * 1000
+        expiresAt
       };
     }
 
@@ -107,7 +131,12 @@ export async function resolveGraphAuth(options?: { token?: string }): Promise<Gr
 
     const cached = await loadCachedGraphToken();
     if (cached && cached.expiresAt > Date.now() + 60_000) {
-      return { success: true, token: cached.accessToken };
+      // Guard against corrupted cache: validate JWT structure before returning
+      if (!isValidJwtStructure(cached.accessToken)) {
+        // Treat a malformed cached token as if there were no cache
+      } else {
+        return { success: true, token: cached.accessToken };
+      }
     }
 
     const refreshTokens = [...new Set([cached?.refreshToken, envRefreshToken].filter((t): t is string => !!t))];


### PR DESCRIPTION
## Summary

Fixes a reliability issue where `resolveAuth()` and `resolveGraphAuth()` could return corrupted tokens from cache, causing opaque 401 Unauthorized errors from Microsoft.

## What changed

Added `isValidJwtStructure()` validation in two places:

1. **Before returning a cached token** — verifies the cached token has 3 dot-separated base64url parts. If validation fails, the cache is treated as empty and the refresh flow runs instead.

2. **Before caching a fresh token** — validates both JWT structure and that the `exp` claim is in the future. Throws if the OAuth server returns a malformed or already-expired token.

## Why

If the token cache file is corrupted by a partial write or external modification, the previous code would return the garbage token without any checks. Now the system self-heals: a bad cache triggers a refresh instead of propagating broken state.

Closes #72