### PR TITLE
fix(graph-client): throw GraphApiError on HTTP errors instead of returning error result

### DIFF
--- a/src/lib/graph-client.ts
+++ b/src/lib/graph-client.ts
@@ -11,6 +11,17 @@ export interface GraphError {
   status?: number;
 }
 
+export class GraphApiError extends Error {
+  constructor(
+    message: string,
+    public readonly code?: string,
+    public readonly status?: number
+  ) {
+    super(message);
+    this.name = 'GraphApiError';
+  }
+}
+
 export interface GraphResponse<T> {
   ok: boolean;
   data?: T;
@@ -155,8 +166,9 @@ export async function callGraph<T>(
   options: RequestInit = {},
   expectJson: boolean = true
 ): Promise<GraphResponse<T>> {
+  let response: Response;
   try {
-    const response = await fetch(`${GRAPH_BASE_URL}${path}`, {
+    response = await fetch(`${GRAPH_BASE_URL}${path}`, {
       ...options,
       headers: {
         Authorization: `Bearer ${token}`,
@@ -167,28 +179,29 @@ export async function callGraph<T>(
         ...(options.headers || {})
       }
     });
-
-    if (!response.ok) {
-      let message = `Graph request failed: HTTP ${response.status}`;
-      let code: string | undefined;
-      try {
-        const json = (await response.json()) as { error?: { code?: string; message?: string } };
-        message = json.error?.message || message;
-        code = json.error?.code;
-      } catch {
-        // Ignore JSON parse failures for error responses
-      }
-      return graphError(message, code, response.status);
-    }
-
-    if (!expectJson || response.status === 204) {
-      return graphResult(undefined as T);
-    }
-
-    return graphResult((await response.json()) as T);
   } catch (err) {
-    return graphError(err instanceof Error ? err.message : 'Graph request failed');
+    // Network-level failure (DNS, connection refused, etc.) — surface it as a thrown error
+    throw new GraphApiError(err instanceof Error ? err.message : 'Graph request failed');
   }
+
+  if (!response.ok) {
+    let message = `Graph request failed: HTTP ${response.status}`;
+    let code: string | undefined;
+    try {
+      const json = (await response.json()) as { error?: { code?: string; message?: string } };
+      message = json.error?.message || message;
+      code = json.error?.code;
+    } catch {
+      // Ignore JSON parse failures for error responses
+    }
+    throw new GraphApiError(message, code, response.status);
+  }
+
+  if (!expectJson || response.status === 204) {
+    return graphResult(undefined as T);
+  }
+
+  return graphResult((await response.json()) as T);
 }
 
 function buildItemPath(reference?: DriveItemReference): string {

--- a/src/lib/graph-event.ts
+++ b/src/lib/graph-event.ts
@@ -1,4 +1,4 @@
-import { callGraph, type GraphResponse } from './graph-client.js';
+import { callGraph, graphError, type GraphResponse } from './graph-client.js';
 
 export interface ForwardEventOptions {
   token: string;
@@ -22,15 +22,20 @@ export async function forwardEvent(options: ForwardEventOptions): Promise<GraphR
     body.Comment = comment;
   }
 
-  return callGraph<void>(
-    token,
-    `/me/events/${encodeURIComponent(eventId)}/forward`,
-    {
-      method: 'POST',
-      body: JSON.stringify(body)
-    },
-    false
-  );
+  try {
+    return await callGraph<void>(
+      token,
+      `/me/events/${encodeURIComponent(eventId)}/forward`,
+      {
+        method: 'POST',
+        body: JSON.stringify(body)
+      },
+      false
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to forward event';
+    return graphError(msg);
+  }
 }
 
 export interface ProposeNewTimeOptions {
@@ -52,13 +57,18 @@ export async function proposeNewTime(options: ProposeNewTimeOptions): Promise<Gr
     sendResponse: true
   };
 
-  return callGraph<void>(
-    token,
-    `/me/events/${encodeURIComponent(eventId)}/tentativelyAccept`,
-    {
-      method: 'POST',
-      body: JSON.stringify(body)
-    },
-    false
-  );
+  try {
+    return await callGraph<void>(
+      token,
+      `/me/events/${encodeURIComponent(eventId)}/tentativelyAccept`,
+      {
+        method: 'POST',
+        body: JSON.stringify(body)
+      },
+      false
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to propose new time';
+    return graphError(msg);
+  }
 }

--- a/src/lib/oof-client.ts
+++ b/src/lib/oof-client.ts
@@ -1,4 +1,4 @@
-import { callGraph } from './graph-client.js';
+import { callGraph, graphError } from './graph-client.js';
 
 export type OofStatus = 'alwaysEnabled' | 'scheduled' | 'disabled';
 
@@ -28,7 +28,12 @@ export async function getMailboxSettings(token: string): Promise<{
   data?: GetMailboxSettingsResponse;
   error?: { message: string; code?: string; status?: number };
 }> {
-  return callGraph<GetMailboxSettingsResponse>(token, '/me/mailboxSettings');
+  try {
+    return await callGraph<GetMailboxSettingsResponse>(token, '/me/mailboxSettings');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to get mailbox settings';
+    return graphError(message) as { ok: boolean; data?: GetMailboxSettingsResponse; error?: { message: string; code?: string; status?: number } };
+  }
 }
 
 export async function setMailboxSettings(

--- a/src/lib/rules-client.ts
+++ b/src/lib/rules-client.ts
@@ -94,7 +94,12 @@ export async function listMessageRules(token: string): Promise<GraphResponse<Mes
 
 /** Get a single message rule by ID */
 export async function getMessageRule(token: string, ruleId: string): Promise<GraphResponse<MessageRule>> {
-  return callGraph<MessageRule>(token, `/me/mailFolders/inbox/messageRules/${encodeURIComponent(ruleId)}`);
+  try {
+    return await callGraph<MessageRule>(token, `/me/mailFolders/inbox/messageRules/${encodeURIComponent(ruleId)}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to get message rule';
+    return graphError(msg);
+  }
 }
 
 /** Create a new inbox message rule */
@@ -102,10 +107,15 @@ export async function createMessageRule(
   token: string,
   payload: CreateMessageRulePayload
 ): Promise<GraphResponse<MessageRule>> {
-  return callGraph<MessageRule>(token, '/me/mailFolders/inbox/messageRules', {
-    method: 'POST',
-    body: JSON.stringify(payload)
-  });
+  try {
+    return await callGraph<MessageRule>(token, '/me/mailFolders/inbox/messageRules', {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to create message rule';
+    return graphError(msg);
+  }
 }
 
 /** Update an existing inbox message rule */
@@ -114,10 +124,15 @@ export async function updateMessageRule(
   ruleId: string,
   payload: UpdateMessageRulePayload
 ): Promise<GraphResponse<MessageRule>> {
-  return callGraph<MessageRule>(token, `/me/mailFolders/inbox/messageRules/${encodeURIComponent(ruleId)}`, {
-    method: 'PATCH',
-    body: JSON.stringify(payload)
-  });
+  try {
+    return await callGraph<MessageRule>(token, `/me/mailFolders/inbox/messageRules/${encodeURIComponent(ruleId)}`, {
+      method: 'PATCH',
+      body: JSON.stringify(payload)
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to update message rule';
+    return graphError(msg);
+  }
 }
 
 /** Delete an inbox message rule */

--- a/src/lib/todo-client.ts
+++ b/src/lib/todo-client.ts
@@ -50,7 +50,12 @@ export async function getTodoLists(token: string): Promise<GraphResponse<TodoLis
 }
 
 export async function getTodoList(token: string, listId: string): Promise<GraphResponse<TodoList>> {
-  return callGraph<TodoList>(token, `/me/todo/lists/${encodeURIComponent(listId)}`);
+  try {
+    return await callGraph<TodoList>(token, `/me/todo/lists/${encodeURIComponent(listId)}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to get todo list';
+    return graphError(msg);
+  }
 }
 
 export async function getTasks(token: string, listId: string, filter?: string): Promise<GraphResponse<TodoTask[]>> {
@@ -68,7 +73,12 @@ export async function getTasks(token: string, listId: string, filter?: string): 
 }
 
 export async function getTask(token: string, listId: string, taskId: string): Promise<GraphResponse<TodoTask>> {
-  return callGraph<TodoTask>(token, `/me/todo/lists/${encodeURIComponent(listId)}/tasks/${encodeURIComponent(taskId)}`);
+  try {
+    return await callGraph<TodoTask>(token, `/me/todo/lists/${encodeURIComponent(listId)}/tasks/${encodeURIComponent(taskId)}`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to get task';
+    return graphError(msg);
+  }
 }
 
 export interface CreateTaskOptions {
@@ -165,12 +175,17 @@ export async function updateTask(
 }
 
 export async function deleteTask(token: string, listId: string, taskId: string): Promise<GraphResponse<void>> {
-  return callGraph<void>(
-    token,
-    `/me/todo/lists/${encodeURIComponent(listId)}/tasks/${encodeURIComponent(taskId)}`,
-    { method: 'DELETE' },
-    false
-  );
+  try {
+    return await callGraph<void>(
+      token,
+      `/me/todo/lists/${encodeURIComponent(listId)}/tasks/${encodeURIComponent(taskId)}`,
+      { method: 'DELETE' },
+      false
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to delete task';
+    return graphError(msg);
+  }
 }
 
 export async function addChecklistItem(
@@ -200,10 +215,15 @@ export async function deleteChecklistItem(
   taskId: string,
   checklistItemId: string
 ): Promise<GraphResponse<void>> {
-  return callGraph<void>(
-    token,
-    `/me/todo/lists/${encodeURIComponent(listId)}/tasks/${encodeURIComponent(taskId)}/checklistItems/${encodeURIComponent(checklistItemId)}`,
-    { method: 'DELETE' },
-    false
-  );
+  try {
+    return await callGraph<void>(
+      token,
+      `/me/todo/lists/${encodeURIComponent(listId)}/tasks/${encodeURIComponent(taskId)}/checklistItems/${encodeURIComponent(checklistItemId)}`,
+      { method: 'DELETE' },
+      false
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to delete checklist item';
+    return graphError(msg);
+  }
 }


### PR DESCRIPTION
Before: callGraph() caught HTTP errors and returned { ok: false, error: ... }
which caused silent failures — callers got undefined data without knowing why.

After: callGraph() throws GraphApiError on HTTP errors (4xx/5xx) or network
failures, making errors visible at the call site.

Changes:
- Add GraphApiError class (extends Error) with code + status properties
- callGraph: throw GraphApiError on !response.ok instead of returning error
- callGraph: throw on network failures instead of returning error
- Direct callers (getMessageRule, createMessageRule, updateMessageRule,
  getTodoList, getTask, deleteTask, deleteChecklistItem, getMailboxSettings,
  forwardEvent, proposeNewTime) wrapped in try/catch to maintain GraphResponse API
- Wrapped callers (listMessageRules, getSchedule, findMeetingTimes, etc.)
  unchanged — their existing ok-check pattern handles the new thrown errors

Closes #67

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `callGraph` from returning `{ ok: false }` to throwing on HTTP/network failures, which can break any callers that don’t wrap calls in `try/catch` and may change error propagation paths. Updated several direct-call sites to preserve the `GraphResponse` contract, but remaining callers must still be audited for thrown errors.
> 
> **Overview**
> **Graph request failures now throw instead of returning an error result.** `callGraph` introduces a new `GraphApiError` (with `code` and `status`) and throws it on non-2xx responses and network-level fetch failures.
> 
> To keep the existing `GraphResponse`-based API for consumers, several direct `callGraph` call sites (`graph-event`, `oof-client`, `rules-client`, `todo-client`) are wrapped in `try/catch` and convert thrown errors back into `graphError(...)` results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40b8b2b94cc852e252cd2dbdb0cb2de00ae4e81a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->