### PR TITLE
fix(recurrence): use local date for RecurrenceRange.StartDate instead of UTC

### DIFF
--- a/src/commands/create-event.ts
+++ b/src/commands/create-event.ts
@@ -256,9 +256,7 @@ export const createEventCommand = new Command('create-event')
         }
 
         // Build range — use local date to avoid UTC shift for late-evening events
-        const localDate = new Intl.DateTimeFormat('en-CA', { // en-CA gives YYYY-MM-DD
-          timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-        }).format(start);
+        const localDate = toLocalISOString(start).split('T')[0];
         const range: RecurrenceRange = {
           Type: 'NoEnd',
           StartDate: localDate


### PR DESCRIPTION
Use Intl.DateTimeFormat with the user's timezone to format the date,
avoiding the UTC shift that caused late-evening events (e.g. 22:00 PST)
to have their recurrence start on the wrong date (next day in UTC).

Closes #117

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to recurrence date formatting that only affects `RecurrenceRange.StartDate` and should prevent off-by-one-day issues for events near midnight in UTC.
> 
> **Overview**
> Updates `create-event` recurrence generation to set `RecurrenceRange.StartDate` from the event’s *local* date (via `toLocalISOString(...).split('T')[0]`) instead of `start.toISOString()`, avoiding UTC-induced day shifts for late-evening events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de00ebec16a1eff4b8f3d03aadc19e50c09be2d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->