### PR TITLE
fix(calendar): interpret YYYY-MM-DD as local midnight (closes #116)

### DIFF
--- a/src/commands/calendar.ts
+++ b/src/commands/calendar.ts
@@ -13,6 +13,27 @@ function formatDate(dateStr: string): string {
   return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
 }
 
+/**
+ * Convert a local-midnight Date to a UTC ISO string for EWS CalendarView.
+ *
+ * EWS CalendarView StartDate/EndDate are UTC-datetime strings.
+ * CalendarView is exclusive on EndDate, so we set end = next day's local midnight.
+ *
+ * Example for UTC-5 (EST) on March 15:
+ *   start = 2024-03-15T00:00 local = 2024-03-15T05:00:00Z
+ *   end   = 2024-03-16T00:00 local = 2024-03-16T05:00:00Z
+ */
+function toEWSRange(localMidnight: Date): { start: string; end: string } {
+  const start = new Date(localMidnight);
+  start.setHours(0, 0, 0, 0);
+
+  const end = new Date(start);
+  end.setDate(end.getDate() + 1);
+  end.setHours(0, 0, 0, 0);
+
+  return { start: start.toISOString(), end: end.toISOString() };
+}
+
 function getDateRange(startDay: string, endDay?: string): { start: string; end: string; label: string } {
   const now = new Date();
 
@@ -26,9 +47,8 @@ function getDateRange(startDay: string, endDay?: string): { start: string; end: 
       start.setDate(start.getDate() + diff);
       start.setHours(0, 0, 0, 0);
       const end = new Date(start);
-      end.setDate(end.getDate() + 6);
-      end.setHours(23, 59, 59, 999);
-      return { start: start.toISOString(), end: end.toISOString(), label: 'This Week' };
+      end.setDate(end.getDate() + 7); // exclusive end = next Monday midnight
+      return { ...toEWSRange(start), end: end.toISOString(), label: 'This Week' };
     }
     case 'lastweek': {
       const start = new Date(now);
@@ -37,9 +57,8 @@ function getDateRange(startDay: string, endDay?: string): { start: string; end: 
       start.setDate(start.getDate() + diff);
       start.setHours(0, 0, 0, 0);
       const end = new Date(start);
-      end.setDate(end.getDate() + 6);
-      end.setHours(23, 59, 59, 999);
-      return { start: start.toISOString(), end: end.toISOString(), label: 'Last Week' };
+      end.setDate(end.getDate() + 7); // exclusive end = next Monday midnight
+      return { ...toEWSRange(start), end: end.toISOString(), label: 'Last Week' };
     }
     case 'nextweek': {
       const start = new Date(now);
@@ -48,9 +67,8 @@ function getDateRange(startDay: string, endDay?: string): { start: string; end: 
       start.setDate(start.getDate() + diff);
       start.setHours(0, 0, 0, 0);
       const end = new Date(start);
-      end.setDate(end.getDate() + 6);
-      end.setHours(23, 59, 59, 999);
-      return { start: start.toISOString(), end: end.toISOString(), label: 'Next Week' };
+      end.setDate(end.getDate() + 7); // exclusive end = next Monday midnight
+      return { ...toEWSRange(start), end: end.toISOString(), label: 'Next Week' };
     }
   }
 
@@ -59,21 +77,23 @@ function getDateRange(startDay: string, endDay?: string): { start: string; end: 
   startDate.setHours(0, 0, 0, 0);
 
   if (endDay) {
-    // Date range - use forwardOnly for end date
+    // Date range - use nearestForward for end date
     const endDate = parseDay(endDay, { baseDate: startDate, weekdayDirection: 'nearestForward' });
-    endDate.setHours(23, 59, 59, 999);
+    endDate.setHours(0, 0, 0, 0);
+    // Exclusive end: next day's midnight
+    const endExclusive = new Date(endDate);
+    endExclusive.setDate(endExclusive.getDate() + 1);
 
     const label = `${formatDate(startDate.toISOString())} - ${formatDate(endDate.toISOString())}`;
-    return { start: startDate.toISOString(), end: endDate.toISOString(), label };
+    return { start: startDate.toISOString(), end: endExclusive.toISOString(), label };
   }
 
-  // Single day
-  const endDate = new Date(startDate);
-  endDate.setHours(23, 59, 59, 999);
+  // Single day — use toEWSRange for consistent UTC conversion
+  const { end: endISO } = toEWSRange(startDate);
 
   return {
     start: startDate.toISOString(),
-    end: endDate.toISOString(),
+    end: endISO,
     label: formatDate(startDate.toISOString())
   };
 }

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -38,6 +38,25 @@ export function toLocalISOString(date: Date): string {
   return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
 }
 
+/**
+ * Parse a YYYY-MM-DD string as local midnight (in the user's timezone),
+ * not UTC midnight. This fixes off-by-one day shifts for UTC-X timezones.
+ *
+ * `new Date('YYYY-MM-DD')` parses as UTC midnight, which becomes the
+ * previous calendar day when local timezone is west of UTC.
+ */
+function parseLocalDate(dayStr: string): Date {
+  const match = dayStr.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return new Date(dayStr);
+  const [, yearStr, monthStr, dayOfMonthStr] = match;
+  return new Date(
+    parseInt(yearStr, 10),
+    parseInt(monthStr, 10) - 1,
+    parseInt(dayOfMonthStr, 10),
+    0, 0, 0, 0
+  );
+}
+
 export function parseDay(day: string, options: ParseDayOptions = {}): Date {
   const { baseDate = new Date(), weekdayDirection = 'next', throwOnInvalid = false } = options;
 
@@ -71,7 +90,8 @@ export function parseDay(day: string, options: ParseDayOptions = {}): Date {
     return now;
   }
 
-  const parsed = new Date(day);
+  // Parse YYYY-MM-DD as local midnight to avoid UTC off-by-one
+  const parsed = parseLocalDate(day);
   if (Number.isNaN(parsed.getTime())) {
     if (throwOnInvalid) {
       throw new Error(`Invalid day value: ${day}`);


### PR DESCRIPTION
## Fix: Date parsing shifts queries backward by one day for UTC-X timezones

### Root Cause
`new Date('YYYY-MM-DD')` in JavaScript parses ISO 8601 date-only strings as **UTC midnight**, not local midnight. For a user in New York (EST = UTC-5), calling `parseDay('2024-03-15')` produced a Date representing `2024-03-15T00:00:00Z` = `19:00 EST` the **previous calendar day** — causing `clippy calendar 2024-03-15` to query March 14 instead.

### Changes

**`src/lib/dates.ts`**
- Added `parseLocalDate()`: parses YYYY-MM-DD by extracting components and calling `new Date(year, month-1, day, 0, 0, 0, 0)` — always creates a local-midnight Date regardless of timezone.
- `parseDay()` now uses `parseLocalDate()` for YYYY-MM-DD strings.

**`src/commands/calendar.ts`**
- `getDateRange()` now uses next-day local midnight as the **exclusive** end boundary for EWS CalendarView, matching the API's exclusive semantics.
- Week ranges (`thisweek`, `lastweek`, `nextweek`) also use exclusive-end pattern.

### Verification
- `bun test src/lib/dates.test.ts` — all 4 tests pass
- `tsc --noEmit` — clean

Closes #116