### PR TITLE
fix(#113): toLocalISOString now includes local timezone offset

### DIFF
--- a/src/lib/dates.test.ts
+++ b/src/lib/dates.test.ts
@@ -11,9 +11,12 @@ describe('dates helpers', () => {
     expect(parseTimeToDate('12am', base).getHours()).toBe(0);
   });
 
-  it('toLocalISOString formats without timezone suffix', () => {
+  it('toLocalISOString formats with local timezone offset', () => {
     const date = new Date(2026, 2, 27, 9, 5, 7);
-    expect(toLocalISOString(date)).toBe('2026-03-27T09:05:07');
+    // Must include a +HH:MM or -HH:MM offset suffix (not Z, not absent)
+    const result = toLocalISOString(date);
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/);
+    expect(result).toMatch(/^2026-03-27T09:05:07[+-]\d{2}:\d{2}$/);
   });
 
   it('parseDay supports relative values and weekday directions', () => {

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -35,7 +35,12 @@ export function toLocalISOString(date: Date): string {
   const hours = String(date.getHours()).padStart(2, '0');
   const minutes = String(date.getMinutes()).padStart(2, '0');
   const seconds = String(date.getSeconds()).padStart(2, '0');
-  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
+  const offsetMinutes = -date.getTimezoneOffset();
+  const offsetSign = offsetMinutes >= 0 ? '+' : '-';
+  const absMinutes = Math.abs(offsetMinutes);
+  const offsetHH = String(Math.floor(absMinutes / 60)).padStart(2, '0');
+  const offsetMM = String(absMinutes % 60).padStart(2, '0');
+  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}${offsetSign}${offsetHH}:${offsetMM}`;
 }
 
 export function parseDay(day: string, options: ParseDayOptions = {}): Date {

--- a/src/lib/ews-client.ts
+++ b/src/lib/ews-client.ts
@@ -1,3 +1,10 @@
+// ─── Timezone Utilities ───────────────────────────────────────────────────────
+
+/** Returns the IANA timezone name for the current process, e.g. 'Europe/Stockholm'. */
+export function getLocalTimezone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone;
+}
+
 // ─── XML Utilities ───
 
 export function xmlEscape(value: string): string {
@@ -411,8 +418,8 @@ function parseCalendarItem(block: string, mailbox?: string): CalendarEvent {
     Id: id,
     ChangeKey: changeKey,
     Subject: subject,
-    Start: { DateTime: start, TimeZone: 'UTC' },
-    End: { DateTime: end, TimeZone: 'UTC' },
+    Start: { DateTime: start, TimeZone: getLocalTimezone() },
+    End: { DateTime: end, TimeZone: getLocalTimezone() },
     Location: location ? { DisplayName: location } : undefined,
     Organizer: { EmailAddress: { Name: organizerName, Address: organizerEmail } },
     Attendees: attendees.length > 0 ? attendees : undefined,
@@ -763,8 +770,8 @@ export async function createEvent(options: CreateEventOptions): Promise<OwaRespo
     return ewsResult({
       Id: id,
       Subject: subject,
-      Start: { DateTime: start, TimeZone: 'UTC' },
-      End: { DateTime: end, TimeZone: 'UTC' },
+      Start: { DateTime: start, TimeZone: getLocalTimezone() },
+      End: { DateTime: end, TimeZone: getLocalTimezone() },
       WebLink: undefined,
       OnlineMeetingUrl: undefined
     });
@@ -887,8 +894,8 @@ export async function updateEvent(options: UpdateEventOptions): Promise<OwaRespo
     return ewsResult({
       Id: newId,
       Subject: subject || '',
-      Start: { DateTime: start || '', TimeZone: 'UTC' },
-      End: { DateTime: end || '', TimeZone: 'UTC' }
+      Start: { DateTime: start || '', TimeZone: getLocalTimezone() },
+      End: { DateTime: end || '', TimeZone: getLocalTimezone() }
     });
   } catch (err) {
     return ewsError(err);


### PR DESCRIPTION
Before: toLocalISOString returned YYYY-MM-DDTHH:mm:ss with NO offset.
When EWS received a datetime without offset, it assumed UTC, silently
shifting meetings by the user's UTC offset (e.g. 13:00 Stockholm = 14:00).

After: toLocalISOString appends the local offset suffix (e.g. +01:00),
so EWS correctly interprets the datetime as the user's local time.

Changes:
- src/lib/dates.ts: toLocalISOString now computes and appends the
  local UTC offset in [+|-]HH:MM format
- src/lib/ews-client.ts: Added getLocalTimezone() helper using
  Intl.DateTimeFormat; replaced all hardcoded TimeZone: 'UTC' in
  createEvent and updateEvent response objects with getLocalTimezone()
- src/lib/dates.test.ts: Updated test to assert offset suffix is present

Closes #113

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how datetimes/timezones are represented for Exchange Web Services events; incorrect offset or timezone resolution could still shift meeting times, especially around DST or non-IANA expectations.
> 
> **Overview**
> Fixes event time shifting by making `toLocalISOString` append the local UTC offset (`±HH:MM`) instead of returning a naive `YYYY-MM-DDTHH:mm:ss` string.
> 
> Adds `getLocalTimezone()` (IANA zone via `Intl`) and replaces hardcoded `TimeZone: 'UTC'` in `ews-client` calendar event parsing/`createEvent`/`updateEvent` result objects with the detected local timezone. Updates tests to assert the offset suffix is present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abca8c45522461fb033fce4c85b70076e24850c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->