### PR TITLE
fix(respond): check IsOrganizer before allowing respond action

### DIFF
--- a/src/commands/respond.ts
+++ b/src/commands/respond.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { resolveAuth } from '../lib/auth.js';
-import { getCalendarEvents, respondToEvent, getOwaUserInfo, type ResponseType } from '../lib/ews-client.js';
+import { getCalendarEvents, respondToEvent, getOwaUserInfo, getCalendarEvent, type ResponseType } from '../lib/ews-client.js';
 
 function formatTime(dateStr: string): string {
   const date = new Date(dateStr);
@@ -204,6 +204,18 @@ export const respondCommand = new Command('respond')
       if (!options.id) {
         console.error('Please specify the event id with --id.');
         console.error('Run `clippy respond list` to see pending invitations and IDs.');
+        process.exit(1);
+      }
+
+      // Look up the event directly to check IsOrganizer (pendingEvents filters out organizer events)
+      const eventResult = await getCalendarEvent(authResult.token!, options.id);
+      if (!eventResult.ok || !eventResult.data) {
+        console.error(`Invalid event id: ${options.id}`);
+        process.exit(1);
+      }
+
+      if (eventResult.data.IsOrganizer) {
+        console.error('You are the organizer of this meeting. Use \'clippy update-event\' instead to modify the meeting.');
         process.exit(1);
       }
 


### PR DESCRIPTION
Check if the user is the organizer when responding to an event via --id.
If they are, show a clear message directing them to use 'clippy update-event'
instead. This prevents confusing responses being sent for one's own meetings.

Closes #64

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CLI behavior change that adds an extra EWS lookup before sending a response; main risk is false blocks or failures if `getCalendarEvent` can’t resolve the event ID in some mailbox scenarios.
> 
> **Overview**
> Updates `clippy respond` to **fetch the target event by `--id` and check `IsOrganizer`** before sending accept/decline/tentative responses.
> 
> If the user is the organizer, the command now exits with a clearer message directing them to use `clippy update-event`, and it also validates the ID via `getCalendarEvent` before proceeding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 600a358a3ed0a22c603a921be254314c969e44ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->