### PR TITLE
fix(cancelEvent): report primary/fallback outcomes clearly instead of masking failures

### DIFF
--- a/src/commands/delete-event.ts
+++ b/src/commands/delete-event.ts
@@ -201,13 +201,17 @@ export const deleteEventCommand = new Command('delete-event')
               success: true,
               action,
               event: targetEvent.Subject,
-              attendeesNotified: hasAttendees && !options.forceDelete ? attendees.length : 0
+              attendeesNotified: hasAttendees && !options.forceDelete ? attendees.length : 0,
+              ...(deleteResult.info ? { info: deleteResult.info } : {})
             },
             null,
             2
           )
         );
       } else {
+        if (deleteResult.info) {
+          console.warn(`\nNote: ${deleteResult.info}\n`);
+        }
         if (hasAttendees && !options.forceDelete) {
           console.log(`\n\u2713 Event cancelled. ${attendees.length} attendee(s) notified.\n`);
         } else {

--- a/src/lib/ews-client.ts
+++ b/src/lib/ews-client.ts
@@ -140,6 +140,8 @@ export interface OwaResponse<T = unknown> {
   status: number;
   data?: T;
   error?: OwaError;
+  /** Informational message (e.g., fallback used, partial success) */
+  info?: string;
 }
 
 export interface OwaUserInfo {
@@ -932,8 +934,10 @@ export interface CancelEventOptions {
 }
 
 export async function cancelEvent(options: CancelEventOptions): Promise<OwaResponse<void>> {
+  const { token, eventId, comment, mailbox } = options;
+
+  // Primary: CancelCalendarItem
   try {
-    const { token, eventId, comment, mailbox } = options;
     const envelope = soapEnvelope(`
     <m:CreateItem MessageDisposition="SendAndSaveCopy">
       <m:Items>
@@ -945,10 +949,9 @@ export async function cancelEvent(options: CancelEventOptions): Promise<OwaRespo
     </m:CreateItem>`);
     await callEws(token, envelope, mailbox);
     return { ok: true, status: 200 };
-  } catch {
-    // Fallback: delete with cancellation notices
+  } catch (primaryErr) {
+    // Fallback: DeleteItem with SendMeetingCancellations
     try {
-      const { token, eventId, mailbox } = options;
       const envelope = soapEnvelope(`
       <m:DeleteItem DeleteType="MoveToDeletedItems" SendMeetingCancellations="SendToAllAndSaveCopy">
         <m:ItemIds>
@@ -956,9 +959,21 @@ export async function cancelEvent(options: CancelEventOptions): Promise<OwaRespo
         </m:ItemIds>
       </m:DeleteItem>`);
       await callEws(token, envelope, mailbox);
-      return { ok: true, status: 200 };
-    } catch (err) {
-      return ewsError(err);
+      // Fallback succeeded after primary failed — report it so caller knows what happened
+      const primaryMsg = primaryErr instanceof Error ? primaryErr.message : String(primaryErr);
+      return { ok: true, status: 200, info: `Primary cancellation failed (${primaryMsg}); cancellation sent via fallback DeleteItem instead.` };
+    } catch (fallbackErr) {
+      // Both failed — report both errors clearly
+      const primaryMsg = primaryErr instanceof Error ? primaryErr.message : String(primaryErr);
+      const fallbackMsg = fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr);
+      return {
+        ok: false,
+        status: 0,
+        error: {
+          code: 'EWS_CANCEL_FAILED',
+          message: `Primary cancellation failed: ${primaryMsg}. Fallback also failed: ${fallbackMsg}`
+        }
+      };
     }
   }
 }


### PR DESCRIPTION
**Bug:** When primary cancellation failed, the fallback could succeed silently leaving no confirmation, or both failures showed only the fallback error.

**Fix:** Track both outcomes — fallback success gets an info message, both failures get a combined error with both reasons.

Closes #60