### PR TITLE
fix(ews-client): add validation to buildRecurrenceXml

### DIFF
--- a/src/lib/ews-client.ts
+++ b/src/lib/ews-client.ts
@@ -666,9 +666,42 @@ export async function getCalendarEvent(token: string, eventId: string): Promise<
   }
 }
 
+/**
+ * Validates required fields on a Recurrence input.
+ * Throws a descriptive Error for any missing required field.
+ */
+function validateRecurrenceInput(recurrence: Recurrence): void {
+  if (!recurrence) {
+    throw new Error('[Recurrence] recurrence object is required');
+  }
+  if (!recurrence.Pattern) {
+    throw new Error('[Recurrence] recurrence.Pattern is required');
+  }
+  if (!recurrence.Range) {
+    throw new Error('[Recurrence] recurrence.Range is required');
+  }
+
+  const { Pattern: p, Range: r } = recurrence;
+
+  if (!r.StartDate || r.StartDate.trim() === '') {
+    throw new Error('[Recurrence] recurrence.Range.StartDate is required');
+  }
+
+  if (r.Type === 'EndDate' && (!r.EndDate || r.EndDate.trim() === '')) {
+    throw new Error('[Recurrence] recurrence.Range.EndDate is required when Range.Type is "EndDate"');
+  }
+
+  if (p.Interval === undefined || p.Interval <= 0) {
+    throw new Error('[Recurrence] recurrence.Pattern.Interval must be a positive integer');
+  }
+}
+
 function buildRecurrenceXml(recurrence: Recurrence): string {
+  validateRecurrenceInput(recurrence);
+
   let patternXml = '';
   const p = recurrence.Pattern;
+  const validTypes = ['Daily', 'Weekly', 'AbsoluteMonthly', 'RelativeMonthly', 'AbsoluteYearly', 'RelativeYearly'] as const;
 
   switch (p.Type) {
     case 'Daily':
@@ -686,16 +719,27 @@ function buildRecurrenceXml(recurrence: Recurrence): string {
       patternXml = `<t:AbsoluteYearlyRecurrence><t:DayOfMonth>${p.DayOfMonth || 1}</t:DayOfMonth><t:Month>${['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'][(p.Month || 1) - 1]}</t:Month></t:AbsoluteYearlyRecurrence>`;
       break;
     default:
+      if (!validTypes.includes(p.Type)) {
+        console.warn(`[Recurrence] Unknown Pattern.Type "${p.Type}", defaulting to Daily`);
+      }
       patternXml = `<t:DailyRecurrence><t:Interval>${p.Interval}</t:Interval></t:DailyRecurrence>`;
   }
 
   let rangeXml = '';
   const r = recurrence.Range;
   switch (r.Type) {
-    case 'EndDate':
-      rangeXml = `<t:EndDateRecurrence><t:StartDate>${xmlEscape(r.StartDate)}</t:StartDate><t:EndDate>${xmlEscape(r.EndDate || r.StartDate)}</t:EndDate></t:EndDateRecurrence>`;
+    case 'EndDate': {
+      const endDate = r.EndDate || r.StartDate;
+      if (!r.EndDate) {
+        console.warn('[Recurrence] Range.EndDate is missing; EndDate will equal StartDate (effectively a single-occurrence event)');
+      }
+      rangeXml = `<t:EndDateRecurrence><t:StartDate>${xmlEscape(r.StartDate)}</t:StartDate><t:EndDate>${xmlEscape(endDate)}</t:EndDate></t:EndDateRecurrence>`;
       break;
+    }
     case 'Numbered':
+      if (r.NumberOfOccurrences === undefined || r.NumberOfOccurrences <= 0) {
+        console.warn('[Recurrence] Range.NumberOfOccurrences is missing or invalid, defaulting to 10');
+      }
       rangeXml = `<t:NumberedRecurrence><t:StartDate>${xmlEscape(r.StartDate)}</t:StartDate><t:NumberOfOccurrences>${r.NumberOfOccurrences || 10}</t:NumberOfOccurrences></t:NumberedRecurrence>`;
       break;
     default:


### PR DESCRIPTION
Closes #65

- Add validateRecurrenceInput() helper that throws descriptive
  errors for missing required fields (recurrence, Pattern, Range,
  Range.StartDate, Range.EndDate for bounded recurrence,
  Pattern.Interval > 0)
- Log console.warn() when defaulting optional fields:
  - Unknown Pattern.Type → falls back to Daily with warning
  - Missing Range.EndDate (EndDate type) → uses StartDate with warning
  - Missing Range.NumberOfOccurrences → defaults to 10 with warning
- Does not break existing valid usage

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new throwing validation and warning logs in `buildRecurrenceXml`, which can change runtime behavior for previously-tolerated malformed recurrence payloads and affect event creation flows.
> 
> **Overview**
> **Tightens recurrence handling for EWS calendar events.** `buildRecurrenceXml` now validates required recurrence fields (e.g., `Pattern`, `Range`, `Range.StartDate`, bounded `Range.EndDate`, and positive `Pattern.Interval`) and throws descriptive errors when invalid.
> 
> When optional/unknown values are encountered, it now emits `console.warn` and applies explicit fallbacks (unknown `Pattern.Type` → Daily, missing `EndDate` → `StartDate`, invalid/missing `NumberOfOccurrences` → 10), making recurrence generation more predictable and diagnosable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 704bb907dcea7a44ae6b26cfba56378b2b252233. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->