### PR TITLE
fix(#57): add JSDoc to encodeGraphSearchQuery explaining AQS encoding

### DIFF
--- a/src/lib/graph-client.ts
+++ b/src/lib/graph-client.ts
@@ -243,9 +243,10 @@ function buildItemPath(reference?: DriveItemReference): string {
 /**
  * Encode a query string for Graph Drive search.
  *
- * encodeURIComponent encodes most characters, but Graph's search(q='...') URL parameter
- * uses single-quoted strings in the URL path. Apostrophes, parentheses, and exclamation marks
- * must therefore also be re-encoded to prevent query syntax injection or truncation.
+ * encodeURIComponent encodes most characters, but it leaves certain characters
+ * like apostrophes and parentheses unescaped. AQS search uses single-quoted
+ * strings in the URL path (for example, search(q='...')), so we also percent-
+ * encode [!'()*] to prevent query syntax injection and keep the path safe.
  *
  * @param query - Raw search query string
  * @returns Percent-encoded query safe for use in Graph search URLs


### PR DESCRIPTION
## Fixes #57

### Changes
Adds a clarifying JSDoc comment to the  function in , explaining why apostrophes and parentheses are explicitly re-encoded after  — AQS uses single-quoted strings in the URL path and these characters must be encoded to prevent query syntax injection.

No functional change — test coverage already exists.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates JSDoc to clarify why additional percent-encoding is applied; no runtime logic changes.
> 
> **Overview**
> Clarifies the JSDoc for `encodeGraphSearchQuery` to explicitly document why `[!'()*]` are re-encoded after `encodeURIComponent` when building Graph AQS `search(q='...')` paths, highlighting injection/truncation prevention.
> 
> No functional behavior changes; the encoding implementation remains the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 534c24e587a27db6efd45504f08945fe0237a1ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->