### PR TITLE
fix(#55): remove dead code in mail.ts and add file size check in drafts.ts

### DIFF
--- a/src/commands/drafts.ts
+++ b/src/commands/drafts.ts
@@ -283,6 +283,11 @@ export const draftsCommand = new Command('drafts')
           for (const filePath of filePaths) {
             try {
               const validated = await validateAttachmentPath(filePath, workingDirectory);
+              const fileStat = await stat(validated.absolutePath);
+              if (fileStat.size > 25 * 1024 * 1024) {
+                console.error(`File too large (>25MB): ${validated.absolutePath}`);
+                process.exit(1);
+              }
               const content = await readFile(validated.absolutePath);
               const contentType = lookupMimeType(validated.fileName) || 'application/octet-stream';
 


### PR DESCRIPTION
## Fixes #55

### Changes
Two fixes:

**mail.ts:** Removes duplicate `if (!id)` guard in the `reply/reply-all` `--send` path. The ID was already validated at the top of the block — the second check was unreachable dead code.

**drafts.ts:** Adds 25MB file size validation to the `--edit` path before reading attachment files, matching the existing check in the `--create` path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core EWS/Graph request, auth-token caching, and calendar update/delete logic (including recurring occurrences), so regressions could affect mailbox operations despite changes being mostly additive and guarded.
> 
> **Overview**
> **Expands calendar/meeting support and hardens EWS/Graph integrations.** Calendar events now parse/display recurrence details, room availability checks are batched via `areRoomsFree`, and `update-event`/`delete-event` can target a single recurring occurrence (with `--occurrence`/`--instance`) plus attendee removal support; EWS requests also gain configurable timeouts and dynamic timezone bias.
> 
> **Improves mail/drafts UX and safety.** Adds `--identity` selection across several commands, prevents attachment download name collisions, validates draft/send attachment paths and enforces 25MB size limits consistently, and removes the `mime-types` dependency in favor of a lightweight `lookupMimeType` helper.
> 
> **Strengthens Graph behavior and security.** Graph auth now requires `GRAPH_REFRESH_TOKEN` (no fallback to EWS refresh tokens), Graph calls add timeouts, file list/search now auto-paginates, downloads validate/allowlist `downloadUrl` hosts and block redirects (SSRF mitigation), and upload/stream handling is tightened with better cleanup.
> 
> CI now emits LCOV coverage output for reporting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69fed5f641d36b16e16165df9edea28dfb3d5262. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->