### PR TITLE
fix: [Issue #52] Prevent silent overwrites when downloading mail attachments

### DIFF
--- a/src/commands/mail.ts
+++ b/src/commands/mail.ts
@@ -267,6 +267,8 @@ export const mailCommand = new Command('mail')
 
         console.log(`\nDownloading ${attachments.length} attachment(s) to ${options.output}/\n`);
 
+        const usedPaths = new Set<string>();
+
         for (const att of attachments) {
           // Get full attachment with content
           const fullAtt = await getAttachment(authResult.token!, emailSummary.data.Id, att.Id);
@@ -279,9 +281,19 @@ export const mailCommand = new Command('mail')
 
           // Resolve the actual file path, avoiding collisions and existing files
           let filePath = join(options.output, att.Name);
-          if (!options.force) {
-            let counter = 1;
-            while (true) {
+          let counter = 1;
+          while (true) {
+            // Always check for intra-download collisions
+            if (usedPaths.has(filePath)) {
+              const ext = extname(att.Name);
+              const base = att.Name.slice(0, att.Name.length - ext.length);
+              filePath = join(options.output, `${base} (${counter})${ext}`);
+              counter++;
+              continue;
+            }
+
+            // Check for pre-existing files only if --force is not set
+            if (!options.force) {
               try {
                 await access(filePath);
                 // File exists — resolve collision with a numeric suffix
@@ -289,13 +301,17 @@ export const mailCommand = new Command('mail')
                 const base = att.Name.slice(0, att.Name.length - ext.length);
                 filePath = join(options.output, `${base} (${counter})${ext}`);
                 counter++;
+                continue;
               } catch {
                 // File doesn't exist — safe to use
-                break;
               }
             }
+
+            // Path is safe to use
+            break;
           }
 
+          usedPaths.add(filePath);
           await writeFile(filePath, content);
 
           const sizeKB = Math.round(content.length / 1024);


### PR DESCRIPTION
## Fix: [Issue #52] mail attachment download silently overwrites existing files

### What was fixed
The `mail --download` command was downloading attachments and blindly writing to disk using the attachment's filename. This caused two problems:
1. Overwriting pre-existing files without warning
2. Attachment name collisions causing intra-download overwrites

### Changes
- Check file existence using `access()` before writing
- If file exists, append a numeric suffix to resolve collisions (e.g. `report (1).pdf`)
- Added `--force` flag to allow explicit overwriting
- Resolves both pre-existing file and intra-attachment name collisions automatically

### Files changed
- `src/commands/mail.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core EWS/Graph client request/response handling (timeouts, recurrence parsing, delete/update semantics) and auth validation, which could affect multiple CLI commands and edge cases in calendar/mail operations.
> 
> **Overview**
> Prevents `mail --download` from silently overwriting files by resolving attachment filename collisions (both existing files and duplicates within the same download) and introducing a `--force` overwrite path.
> 
> Expands calendar functionality: `create-event` supports `--all-day` and uses batched room availability checks; `update-event`/`delete-event` can target single recurring occurrences (by index/date) and support attendee removal and all-day toggling; `calendar -v` now displays recurrence details.
> 
> Hardens and refactors service clients: EWS and Graph calls gain configurable request timeouts, stricter non-empty ID validation, safer token/identity handling (including identity name validation), more explicit Graph auth requirements, and additional security checks for Graph download URLs. Also removes the `mime-types` dependency in favor of a lightweight internal `lookupMimeType` helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad60855d7504e93040505d0769850d2d2b3302ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->