### PR TITLE
Fix #78: Add --timezone flag and fix hardcoded UTC/CET timezone bias

### DIFF
--- a/src/commands/create-event.ts
+++ b/src/commands/create-event.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { resolveAuth } from '../lib/auth.js';
-import { parseDay, parseTimeToDate, toUTCISOString } from '../lib/dates.js';
+import { parseDay, parseTimeToDate, toUTCISOString, toLocalISOString } from '../lib/dates.js';
 import {
   createEvent,
   getRooms,
@@ -284,8 +284,8 @@ export const createEventCommand = new Command('create-event')
       const result = await createEvent({
         token: authResult.token!,
         subject: title,
-        start: toUTCISOString(start),
-        end: toUTCISOString(end),
+        start: options.timezone ? toLocalISOString(start) : toUTCISOString(start),
+        end: options.timezone ? toLocalISOString(end) : toUTCISOString(end),
         body: options.description,
         location: roomName,
         attendees: attendees.length > 0 ? attendees : undefined,

--- a/src/commands/update-event.ts
+++ b/src/commands/update-event.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { resolveAuth } from '../lib/auth.js';
-import { parseDay, parseTimeToDate, toUTCISOString } from '../lib/dates.js';
+import { parseDay, parseTimeToDate, toUTCISOString, toLocalISOString } from '../lib/dates.js';
 import { getCalendarEvents, getRooms, searchRooms, updateEvent } from '../lib/ews-client.js';
 
 function formatTime(dateStr: string): string {
@@ -234,12 +234,12 @@ export const updateEventCommand = new Command('update-event')
 
         if (options.start) {
           const newStart = parseTimeToDate(options.start, eventDate);
-          updateOptions.start = toUTCISOString(newStart);
+          updateOptions.start = options.timezone ? toLocalISOString(newStart) : toUTCISOString(newStart);
         }
 
         if (options.end) {
           const newEnd = parseTimeToDate(options.end, eventDate);
-          updateOptions.end = toUTCISOString(newEnd);
+          updateOptions.end = options.timezone ? toLocalISOString(newEnd) : toUTCISOString(newEnd);
         }
       }
 

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -32,6 +32,17 @@ export function toUTCISOString(date: Date): string {
   return date.toISOString();
 }
 
+export function toLocalISOString(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
+  const ms = String(date.getMilliseconds()).padStart(3, '0');
+  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}.${ms}`;
+}
+
 /**
  * Parse a date string that may have a timezone offset suffix (e.g. "+01:00")
  * and return the local date components in the user's system timezone.

--- a/src/lib/ews-client.ts
+++ b/src/lib/ews-client.ts
@@ -1968,15 +1968,15 @@ function buildEWSTimeZoneXml(): string {
         <t:Bias>${offsetMinutes}</t:Bias>
         <t:StandardTime>
           <t:Bias>${janStdBias}</t:Bias>
-          <t:Time>00:00:00</t:Time>
-          <t:DayOrder>1</t:DayOrder>
+          <t:Time>03:00:00</t:Time>
+          <t:DayOrder>5</t:DayOrder>
           <t:Month>10</t:Month>
           <t:DayOfWeek>Sunday</t:DayOfWeek>
         </t:StandardTime>
         <t:DaylightTime>
           <t:Bias>${julDstBias}</t:Bias>
-          <t:Time>00:00:00</t:Time>
-          <t:DayOrder>1</t:DayOrder>
+          <t:Time>02:00:00</t:Time>
+          <t:DayOrder>5</t:DayOrder>
           <t:Month>3</t:Month>
           <t:DayOfWeek>Sunday</t:DayOfWeek>
         </t:DaylightTime>


### PR DESCRIPTION
Fixes #78

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches calendar date/time handling and EWS SOAP timezone fields, which can shift event times or affect availability/room-free calculations if incorrect. Scope is contained to event create/update and availability requests, but behavior changes are user-visible.
> 
> **Overview**
> Adds explicit timezone handling to event creation and updates: `create-event`/`update-event` now accept `--timezone` (and `--all-day` / `--no-all-day` for updates) and pass `timezone`/`isAllDay` through to EWS.
> 
> Updates EWS calendar SOAP generation/parsing to set and read `StartTimeZone`/`EndTimeZone`, and introduces `toLocalISOString` so timestamps can be sent without UTC conversion when a timezone is specified.
> 
> Fixes availability/room-free requests by replacing a hardcoded CET/UTC bias in `GetUserAvailability` with a computed timezone XML based on the system’s local offset (incl. DST).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 821dbabb9b5827654db670ab1bba9a15fa021db7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->