### PR TITLE
Fix #56

### DIFF
--- a/src/commands/drafts.ts
+++ b/src/commands/drafts.ts
@@ -1,5 +1,4 @@
-import { readFile, stat } from 'node:fs/promises';
-import { basename } from 'node:path';
+import { readFile } from 'node:fs/promises';
 import { Command } from 'commander';
 import { lookup } from 'mime-types';
 import { resolveAuth } from '../lib/auth.js';
@@ -148,6 +147,7 @@ export const draftsCommand = new Command('drafts')
         }
 
         // Add attachments if specified
+        const workingDirectory = process.cwd();
         if (options.attach) {
           const filePaths = options.attach
             .split(',')
@@ -155,28 +155,28 @@ export const draftsCommand = new Command('drafts')
             .filter(Boolean);
           for (const filePath of filePaths) {
             try {
-              const fileStat = await stat(filePath);
-              if (fileStat.size > 25 * 1024 * 1024) {
-                console.error(`File too large (>25MB): ${filePath}`);
-                process.exit(1);
-              }
-              const content = await readFile(filePath);
-              const fileName = basename(filePath);
-              const contentType = lookup(filePath) || 'application/octet-stream';
+              const validated = await validateAttachmentPath(filePath, workingDirectory);
+              const content = await readFile(validated.absolutePath);
+              const contentType = lookup(validated.fileName) || 'application/octet-stream';
 
               const attachResult = await addAttachmentToDraft(authResult.token!, result.data.Id, {
-                name: fileName,
+                name: validated.fileName,
                 contentType,
                 contentBytes: content.toString('base64')
               });
 
               if (!attachResult.ok) {
-                console.error(`Failed to attach ${fileName}: ${attachResult.error?.message}`);
+                console.error(`Failed to attach ${validated.fileName}: ${attachResult.error?.message}`);
               } else if (!options.json) {
-                console.log(`  Attached: ${fileName}`);
+                console.log(`  Attached: ${validated.fileName}`);
               }
-            } catch (_err) {
-              console.error(`Failed to read: ${filePath}`);
+            } catch (err) {
+              if (err instanceof AttachmentPathError) {
+                console.error(`Invalid attachment path: ${filePath}: ${err.message}`);
+              } else {
+                console.error(`Failed to attach: ${filePath}`);
+              }
+              process.exit(1);
             }
           }
         }

--- a/src/commands/mail.ts
+++ b/src/commands/mail.ts
@@ -283,11 +283,13 @@ export const mailCommand = new Command('mail')
           const ext = att.Name.includes('.') ? '.' + att.Name.split('.').pop() : '';
           const baseName = ext ? att.Name.slice(0, -ext.length) : att.Name;
           let counter = 1;
+          let finalFileName = att.Name;
           while (true) {
             try {
               await access(filePath);
               // File exists — try a suffixed name
-              filePath = join(options.output, ext ? `${baseName} (${counter})${ext}` : `${att.Name} (${counter})`);
+              finalFileName = ext ? `${baseName} (${counter})${ext}` : `${att.Name} (${counter})`;
+              filePath = join(options.output, finalFileName);
               counter++;
             } catch {
               // File doesn't exist, safe to write
@@ -298,7 +300,7 @@ export const mailCommand = new Command('mail')
           await writeFile(filePath, content);
 
           const sizeKB = Math.round(content.length / 1024);
-          console.log(`  \u2713 ${att.Name} (${sizeKB} KB)`);
+          console.log(`  \u2713 ${finalFileName} (${sizeKB} KB)`);
         }
 
         console.log('\nDone.\n');

--- a/src/lib/ews-client.ts
+++ b/src/lib/ews-client.ts
@@ -638,7 +638,7 @@ export async function getCalendarEvent(
   mailbox?: string
 ): Promise<OwaResponse<CalendarEvent>> {
   try {
-    requireNonEmpty(eventId, 'eventId');
+    eventId = requireNonEmpty(eventId, 'eventId');
     const envelope = soapEnvelope(`
     <m:GetItem>
       <m:ItemShape>
@@ -969,8 +969,8 @@ export interface DeleteEventOptions {
 
 export async function deleteEvent(options: DeleteEventOptions): Promise<OwaResponse<void>> {
   try {
-    const { token, eventId, mailbox } = options;
-    requireNonEmpty(eventId, 'eventId');
+    let { token, eventId, mailbox } = options;
+    eventId = requireNonEmpty(eventId, 'eventId');
     const envelope = soapEnvelope(`
     <m:DeleteItem DeleteType="MoveToDeletedItems" SendMeetingCancellations="SendToNone">
       <m:ItemIds>
@@ -1150,7 +1150,7 @@ export async function getEmails(options: GetEmailsOptions): Promise<OwaResponse<
 
 export async function getEmail(token: string, messageId: string): Promise<OwaResponse<EmailMessage>> {
   try {
-    requireNonEmpty(messageId, 'messageId');
+    messageId = requireNonEmpty(messageId, 'messageId');
     const envelope = soapEnvelope(`
     <m:GetItem>
       <m:ItemShape>
@@ -1552,7 +1552,7 @@ async function sendItemById(token: string, itemId: string): Promise<void> {
 
 export async function sendDraftById(token: string, draftId: string): Promise<OwaResponse<void>> {
   try {
-    requireNonEmpty(draftId, 'draftId');
+    draftId = requireNonEmpty(draftId, 'draftId');
     await sendItemById(token, draftId);
     return { ok: true, status: 200 };
   } catch (err) {
@@ -1562,7 +1562,7 @@ export async function sendDraftById(token: string, draftId: string): Promise<Owa
 
 export async function deleteDraftById(token: string, draftId: string): Promise<OwaResponse<void>> {
   try {
-    requireNonEmpty(draftId, 'draftId');
+    draftId = requireNonEmpty(draftId, 'draftId');
     const envelope = soapEnvelope(`
     <m:DeleteItem DeleteType="HardDelete">
       <m:ItemIds>


### PR DESCRIPTION
Fixes #56

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes around attachment paths and ID validation can cause previously-accepted inputs to fail fast, and the attachment download rename loop changes filesystem write behavior. Changes are localized to CLI flows and input validation, with low security risk and improved safety overall.
> 
> **Overview**
> **Hardens attachment handling in the CLI.** `clippy drafts --attach` now validates attachment paths via `validateAttachmentPath` (rejecting absolute paths, traversal, symlinks, missing/non-files, and >25MB) and fails with clearer errors.
> 
> **Improves mail attachment downloads.** `clippy mail --download` now avoids overwriting existing files by auto-suffixing duplicate filenames (e.g., `file (1).ext`) and logs the final written name.
> 
> **Adds stricter ID validation and small correctness tweaks.** EWS client methods (`getEmail`, `getCalendarEvent`, `sendDraftById`, `deleteDraftById`, `deleteEvent`) now reject empty IDs early, `drafts --delete` errors on missing IDs, and room listing fetches rooms from all room lists concurrently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0be7d0696fc7ec60f41a5f49587f0fd4d4ae65d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->