### PR TITLE
Fix #58

### DIFF
--- a/src/commands/mail.ts
+++ b/src/commands/mail.ts
@@ -151,22 +151,14 @@ export const mailCommand = new Command('mail')
       const page = parseInt(options.page, 10) || 1;
       const skip = (page - 1) * limit;
 
-      // Build filter
-      const filters: string[] = [];
-      if (options.unread) {
-        filters.push('IsRead eq false');
-      }
-      if (options.flagged) {
-        filters.push("Flag/FlagStatus eq 'Flagged'");
-      }
-
       const result = await getEmails({
         token: authResult.token!,
         folder: apiFolder,
         top: limit,
         skip,
-        filter: filters.length > 0 ? filters.join(' and ') : undefined,
-        search: options.search
+        search: options.search,
+        isRead: options.unread ? false : undefined,
+        flagStatus: options.flagged ? 'Flagged' : undefined
       });
 
       if (!result.ok || !result.data) {

--- a/src/lib/ews-client.ts
+++ b/src/lib/ews-client.ts
@@ -297,6 +297,8 @@ export interface GetEmailsOptions {
   search?: string;
   select?: string[];
   orderBy?: string;
+  isRead?: boolean;
+  flagStatus?: 'Flagged' | 'NotFlagged' | 'Complete';
 }
 
 export interface Attachment {
@@ -1064,21 +1066,36 @@ export async function respondToEvent(options: RespondToEventOptions): Promise<Ow
 
 export async function getEmails(options: GetEmailsOptions): Promise<OwaResponse<EmailListResponse>> {
   try {
-    const { token, folder = 'inbox', top = 10, skip = 0, filter, search } = options;
+    const { token, folder = 'inbox', top = 10, skip = 0, filter, search, isRead, flagStatus } = options;
 
     // Build restriction for filters
     let restrictionXml = '';
-    if (filter && !search) {
+    if (!search) {
       const restrictions: string[] = [];
 
-      if (filter.includes('IsRead eq false')) {
+      if (isRead !== undefined) {
+        restrictions.push(`
+        <t:IsEqualTo>
+          <t:FieldURI FieldURI="message:IsRead" />
+          <t:FieldURIOrConstant><t:Constant Value="${isRead ? 'true' : 'false'}" /></t:FieldURIOrConstant>
+        </t:IsEqualTo>`);
+      } else if (filter?.includes('IsRead eq false')) {
+        // Fallback for legacy filter string
         restrictions.push(`
         <t:IsEqualTo>
           <t:FieldURI FieldURI="message:IsRead" />
           <t:FieldURIOrConstant><t:Constant Value="false" /></t:FieldURIOrConstant>
         </t:IsEqualTo>`);
       }
-      if (filter.includes('FlagStatus') && filter.includes('Flagged')) {
+
+      if (flagStatus) {
+        restrictions.push(`
+        <t:IsEqualTo>
+          <t:FieldURI FieldURI="item:Flag/FlagStatus" />
+          <t:FieldURIOrConstant><t:Constant Value="${flagStatus}" /></t:FieldURIOrConstant>
+        </t:IsEqualTo>`);
+      } else if (filter?.includes('FlagStatus') && filter?.includes('Flagged')) {
+        // Fallback for legacy filter string
         restrictions.push(`
         <t:IsEqualTo>
           <t:FieldURI FieldURI="item:Flag/FlagStatus" />


### PR DESCRIPTION
Fixes #58

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `getEmails` builds EWS restrictions for unread/flagged filtering, which can affect which messages are returned and how search interacts with filters. Low blast radius but requires validation against EWS behavior across mailboxes/folders.
> 
> **Overview**
> Fixes email listing filters by moving unread/flagged logic from a string-based `filter` into explicit `getEmails` options (`isRead`, `flagStatus`) and generating the corresponding EWS restriction XML.
> 
> `getEmails` now applies these restrictions only when *not* using `search` (keeping the existing query-string search path), while retaining a fallback that still understands the legacy `filter` string format.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56a5e86f182c2e657c63f3047929645661dc7523. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->