### PR TITLE
Fix #59

### DIFF
--- a/src/lib/ews-client.ts
+++ b/src/lib/ews-client.ts
@@ -832,6 +832,17 @@ export async function createEvent(options: CreateEventOptions): Promise<OwaRespo
   }
 }
 
+/**
+ * Updates an existing calendar event.
+ *
+ * NOTE regarding attendees: In EWS, `SetItemField` for `calendar:RequiredAttendees` (or Optional/Resource)
+ * replaces the *entire attendee list*. To add or remove an attendee, you must fetch the event,
+ * manipulate the attendees array locally, and pass the full list back here.
+ * This introduces a potential race condition: if an attendee is added/removed externally between the
+ * fetch and update steps, those changes will be overwritten.
+ * 
+ * Future improvement: provide explicit add/remove delta operations if needed.
+ */
 export async function updateEvent(options: UpdateEventOptions): Promise<OwaResponse<CreatedEvent>> {
   try {
     const { token, eventId, changeKey, subject, start, end, body, location, attendees, mailbox } = options;


### PR DESCRIPTION
Fixes #59

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change; no runtime behavior or API contract changes. Low risk aside from potential reviewer confusion if the note is misunderstood.
> 
> **Overview**
> Adds an explanatory doc comment to `updateEvent` in `src/lib/ews-client.ts` clarifying that EWS attendee updates via `SetItemField` replace the entire attendee list and can overwrite external changes if callers do a fetch-modify-update flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bc996a6b6a9d1a8243795850c3ba4e0ea3f973e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->