### PR TITLE
Fix #76: Cannot delete a single occurrence of a recurring event

### DIFF
--- a/src/commands/delete-event.ts
+++ b/src/commands/delete-event.ts
@@ -170,7 +170,7 @@ export const deleteEventCommand = new Command('delete-event')
           startInst.setHours(0, 0, 0, 0);
           const endInst = new Date(instDate);
           endInst.setHours(23, 59, 59, 999);
-          
+
           const instResult = await getCalendarEvents(
             authResult.token!,
             startInst.toISOString(),
@@ -178,14 +178,22 @@ export const deleteEventCommand = new Command('delete-event')
             options.mailbox
           );
 
-          if (instResult.ok && instResult.data) {
-             const occurrence = instResult.data.find(e => (e.RecurringMasterItemId === targetEvent.Id || e.Id === targetEvent.Id || e.Subject === targetEvent.Subject));
-             if (occurrence) {
-                targetEvent.Id = occurrence.Id; // swap to occurrence ID
-             } else {
-                console.error(`Could not find occurrence of "${targetEvent.Subject}" on ${options.instance}`);
-                process.exit(1);
-             }
+          if (!instResult.ok || !instResult.data) {
+            console.error(`Error: ${instResult.error?.message || 'Failed to fetch instance events'}`);
+            process.exit(1);
+          }
+
+          const occurrence = instResult.data.find(
+            (e) =>
+              e.RecurringMasterItemId === targetEvent.RecurringMasterItemId ||
+              e.Id === targetEvent.Id ||
+              e.Subject === targetEvent.Subject
+          );
+          if (occurrence) {
+            targetEvent.Id = occurrence.Id; // swap to occurrence ID
+          } else {
+            console.error(`Could not find occurrence of "${targetEvent.Subject}" on ${options.instance}`);
+            process.exit(1);
           }
         } catch (err) {
           console.error(`Failed to find instance: ${err}`);
@@ -193,16 +201,23 @@ export const deleteEventCommand = new Command('delete-event')
         }
       }
 
-      // Handle scope logic
+      // Handle scope logic and occurrence index
       if (options.scope === 'all') {
         if (targetEvent.RecurringMasterItemId) {
           targetEvent.Id = targetEvent.RecurringMasterItemId;
         }
+      } else if (options.occurrence && targetEvent.RecurringMasterItemId) {
+        // When using --occurrence with an occurrence ID, swap to master ID
+        targetEvent.Id = targetEvent.RecurringMasterItemId;
       } else if (options.scope === 'future') {
-        console.warn('Note: --scope future is handled via setting the series EndDate. If it fails, you may need to manually edit the series.');
+        console.warn(
+          'Note: --scope future is handled via setting the series EndDate. If it fails, you may need to manually edit the series.'
+        );
         // For 'future', updating EndDate is complex via CLI since updateEvent doesn't handle RecurrenceEnd updates directly.
         // EWS natively doesn't have "delete future" for deleteItem.
-        console.error('--scope future is not natively supported by EWS DeleteItem. Please manually update the recurring event EndDate.');
+        console.error(
+          '--scope future is not natively supported by EWS DeleteItem. Please manually update the recurring event EndDate.'
+        );
         process.exit(1);
       }
 

--- a/src/lib/ews-client.ts
+++ b/src/lib/ews-client.ts
@@ -361,7 +361,11 @@ function parseCalendarItem(block: string, mailbox?: string): CalendarEvent {
   const bodyPreview = extractTag(block, 'TextBody') || extractTag(block, 'Body');
 
   const recurringMasterBlock = extractSelfClosingOrBlock(block, 'RecurringMasterItemId');
-  const recurringMasterItemId = recurringMasterBlock ? extractAttribute(recurringMasterBlock, 'RecurringMasterItemId', 'OccurrenceId') || extractAttribute(recurringMasterBlock, 'RecurringMasterItemId', 'Id') || extractAttribute(block, 'RecurringMasterItemId', 'Id') : undefined;
+  const recurringMasterItemId = recurringMasterBlock
+    ? extractAttribute(recurringMasterBlock, 'RecurringMasterItemId', 'OccurrenceId') ||
+      extractAttribute(recurringMasterBlock, 'RecurringMasterItemId', 'Id') ||
+      extractAttribute(block, 'RecurringMasterItemId', 'Id')
+    : undefined;
   const importance = extractTag(block, 'Importance') || 'Normal';
   const showAs = extractTag(block, 'LegacyFreeBusyStatus') || 'Busy';
 
@@ -976,9 +980,10 @@ export interface DeleteEventOptions {
 export async function deleteEvent(options: DeleteEventOptions): Promise<OwaResponse<void>> {
   try {
     const { token, eventId, mailbox, occurrenceIndex } = options;
-    const itemIdXml = occurrenceIndex !== undefined
-      ? `<t:OccurrenceItemId RecurringMasterId="${xmlEscape(eventId)}" InstanceIndex="${occurrenceIndex}" />`
-      : `<t:ItemId Id="${xmlEscape(eventId)}" />`;
+    const itemIdXml =
+      occurrenceIndex !== undefined
+        ? `<t:OccurrenceItemId RecurringMasterId="${xmlEscape(eventId)}" InstanceIndex="${occurrenceIndex}" />`
+        : `<t:ItemId Id="${xmlEscape(eventId)}" />`;
 
     const envelope = soapEnvelope(`
     <m:DeleteItem DeleteType="MoveToDeletedItems" SendMeetingCancellations="SendToNone">
@@ -1004,57 +1009,70 @@ export interface CancelEventOptions {
 export async function cancelEvent(options: CancelEventOptions): Promise<OwaResponse<void>> {
   const { token, eventId, comment, mailbox, occurrenceIndex } = options;
 
-  const itemIdXml = occurrenceIndex !== undefined
-    ? `<t:OccurrenceItemId RecurringMasterId="${xmlEscape(eventId)}" InstanceIndex="${occurrenceIndex}" />`
-    : `<t:ItemId Id="${xmlEscape(eventId)}" />`;
+  const itemIdXml =
+    occurrenceIndex !== undefined
+      ? `<t:OccurrenceItemId RecurringMasterId="${xmlEscape(eventId)}" InstanceIndex="${occurrenceIndex}" />`
+      : `<t:ItemId Id="${xmlEscape(eventId)}" />`;
 
-  const referenceItemIdXml = occurrenceIndex !== undefined
-    ? `<t:OccurrenceItemId RecurringMasterId="${xmlEscape(eventId)}" InstanceIndex="${occurrenceIndex}" />`
-    : `<t:ReferenceItemId Id="${xmlEscape(eventId)}" />`;
-
-  // Primary: CancelCalendarItem
-  try {
-    const envelope = soapEnvelope(`
-    <m:CreateItem MessageDisposition="SendAndSaveCopy">
-      <m:Items>
-        <t:CancelCalendarItem>
-          ${referenceItemIdXml}
-          ${comment ? `<t:NewBodyContent BodyType="Text">${xmlEscape(comment)}</t:NewBodyContent>` : ''}
-        </t:CancelCalendarItem>
-      </m:Items>
-    </m:CreateItem>`);
-    await callEws(token, envelope, mailbox);
-    return { ok: true, status: 200 };
-  } catch (primaryErr) {
-    // Fallback: DeleteItem with SendMeetingCancellations
+  // CancelCalendarItem only works with ReferenceItemId (not OccurrenceItemId)
+  // For occurrences, skip primary path and use DeleteItem directly
+  if (occurrenceIndex === undefined) {
+    // Primary: CancelCalendarItem (only for non-occurrence deletions)
     try {
       const envelope = soapEnvelope(`
-      <m:DeleteItem DeleteType="MoveToDeletedItems" SendMeetingCancellations="SendToAllAndSaveCopy">
-        <m:ItemIds>
-          ${itemIdXml}
-        </m:ItemIds>
-      </m:DeleteItem>`);
+      <m:CreateItem MessageDisposition="SendAndSaveCopy">
+        <m:Items>
+          <t:CancelCalendarItem>
+            <t:ReferenceItemId Id="${xmlEscape(eventId)}" />
+            ${comment ? `<t:NewBodyContent BodyType="Text">${xmlEscape(comment)}</t:NewBodyContent>` : ''}
+          </t:CancelCalendarItem>
+        </m:Items>
+      </m:CreateItem>`);
       await callEws(token, envelope, mailbox);
-      // Fallback succeeded after primary failed — report it so caller knows what happened
-      const primaryMsg = primaryErr instanceof Error ? primaryErr.message : String(primaryErr);
-      return {
-        ok: true,
-        status: 200,
-        info: `Primary cancellation failed (${primaryMsg}); cancellation sent via fallback DeleteItem instead.`
-      };
-    } catch (fallbackErr) {
-      // Both failed — report both errors clearly
-      const primaryMsg = primaryErr instanceof Error ? primaryErr.message : String(primaryErr);
-      const fallbackMsg = fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr);
-      return {
-        ok: false,
-        status: 0,
-        error: {
-          code: 'EWS_CANCEL_FAILED',
-          message: `Primary cancellation failed: ${primaryMsg}. Fallback also failed: ${fallbackMsg}`
-        }
-      };
+      return { ok: true, status: 200 };
+    } catch (primaryErr) {
+      // Fallback: DeleteItem with SendMeetingCancellations
+      try {
+        const envelope = soapEnvelope(`
+        <m:DeleteItem DeleteType="MoveToDeletedItems" SendMeetingCancellations="SendToAllAndSaveCopy">
+          <m:ItemIds>
+            ${itemIdXml}
+          </m:ItemIds>
+        </m:DeleteItem>`);
+        await callEws(token, envelope, mailbox);
+        const primaryMsg = primaryErr instanceof Error ? primaryErr.message : String(primaryErr);
+        return {
+          ok: true,
+          status: 200,
+          info: `Primary cancellation failed (${primaryMsg}); cancellation sent via fallback DeleteItem instead.`
+        };
+      } catch (fallbackErr) {
+        const primaryMsg = primaryErr instanceof Error ? primaryErr.message : String(primaryErr);
+        const fallbackMsg = fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr);
+        return {
+          ok: false,
+          status: 0,
+          error: {
+            code: 'EWS_CANCEL_FAILED',
+            message: `Primary cancellation failed: ${primaryMsg}. Fallback also failed: ${fallbackMsg}`
+          }
+        };
+      }
     }
+  }
+
+  // For occurrences, use DeleteItem directly (CancelCalendarItem doesn't support OccurrenceItemId)
+  try {
+    const envelope = soapEnvelope(`
+    <m:DeleteItem DeleteType="MoveToDeletedItems" SendMeetingCancellations="SendToAllAndSaveCopy">
+      <m:ItemIds>
+        ${itemIdXml}
+      </m:ItemIds>
+    </m:DeleteItem>`);
+    await callEws(token, envelope, mailbox);
+    return { ok: true, status: 200 };
+  } catch (err) {
+    return ewsError(err);
   }
 }
 


### PR DESCRIPTION
Fixes #76. Adds --occurrence, --instance, and --scope flags to delete-event.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes calendar deletion/cancellation behavior and introduces new EWS request shapes (`OccurrenceItemId`) that could affect which items get removed or how cancellations are sent.
> 
> **Overview**
> Adds support for deleting/cancelling *individual occurrences* of recurring calendar events via new `delete-event` flags: `--occurrence` (instance index), `--instance` (date lookup), and `--scope` (with `future` explicitly rejected and `all` mapping to master deletion).
> 
> Extends the EWS client to fetch recurrence metadata (`CalendarItemType`, `RecurringMasterItemId`) and updates `deleteEvent`/`cancelEvent` to target occurrences using `OccurrenceItemId`; for occurrence cancellations, it skips `CancelCalendarItem` and uses `DeleteItem` with meeting cancellations instead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d8f13c7600677ef9cbf7bc528fd3c39b16603e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->