### PR TITLE
fix/issue-40: Validate downloadUrl before fetch to prevent SSRF

### DIFF
--- a/src/lib/graph-client.ts
+++ b/src/lib/graph-client.ts
@@ -419,7 +419,12 @@ export async function downloadFile(
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
-      const response = await fetch(url.toString());
+      const response = await fetch(url.toString(), { redirect: 'manual' });
+
+      // Reject redirects to prevent SSRF bypass
+      if (response.status >= 300 && response.status < 400) {
+        return graphError('Download failed: redirects are not permitted for security reasons');
+      }
 
       if (!response.ok) {
         // Non-transient HTTP errors: don't retry


### PR DESCRIPTION
## Summary
Implements security fix for issue #40: validates the `@microsoft.graph.downloadUrl` before passing it to `fetch()` to prevent:
- `javascript:` or `data:` URI evaluation
- Bearer token exfiltration via redirect to attacker-controlled origin (SSRF)

## Changes
**File:** `src/lib/graph-client.ts` — `downloadFile()`

- Added URL validation: checks that the URL parses successfully
- Added protocol allowlist: only `https:` permitted
- Added hostname allowlist: only known Microsoft domains permitted
- Returns `GraphResponse` error on validation failure

## Security
Fixes OWASP A01:2021 — Broken Access Control

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens `downloadFile()` network behavior by enforcing an HTTPS/domain allowlist and disallowing redirects, which could break downloads for tenants/clouds using unexpected hostnames or redirect-based URLs.
> 
> **Overview**
> Hardens `downloadFile()` by validating `@microsoft.graph.downloadUrl` before fetching: it must parse as a URL, use `https:`, and have a hostname in an explicit Microsoft allowlist (including sovereign cloud domains).
> 
> The download request now uses `fetch(..., { redirect: 'manual' })` and fails on any 3xx response to prevent redirect-based SSRF/token exfiltration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e000c6f296bb3ef4155b7de975582f2a381058e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->