### PR TITLE
fix/issue-42: Log token cache write failures instead of silently ignoring

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -41,8 +41,8 @@ async function saveCachedToken(identity: string, token: CachedToken): Promise<vo
       encoding: 'utf-8',
       mode: 0o600
     });
-  } catch {
-    // Ignore write errors
+  } catch (err) {
+    console.error(`Failed to write token cache for identity '${identity}':`, err instanceof Error ? err.message : err);
   }
 }
 

--- a/src/lib/graph-auth.ts
+++ b/src/lib/graph-auth.ts
@@ -41,8 +41,8 @@ async function saveCachedGraphToken(token: CachedGraphToken): Promise<void> {
       encoding: 'utf-8',
       mode: 0o600
     });
-  } catch {
-    // Ignore cache write failures
+  } catch (err) {
+    console.error('Failed to write Graph token cache:', err instanceof Error ? err.message : err);
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes issue #42: silent token cache write failures that cause persistent auth failures after refresh token rotation.

## Changes
**Files:** `src/lib/auth.ts` (saveCachedToken), `src/lib/graph-auth.ts` (saveCachedGraphToken)

- Changed catch blocks from silent `// Ignore` to `console.error()` with the error message
- For EWS token cache: includes the identity in the error message
- For Graph token cache: includes the error message for debugging

## Impact
Users will now be notified when token cache writes fail, preventing silent auth failures that persist until manual env updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes error handling to log cache write failures, with no changes to token refresh logic or cache formats.
> 
> **Overview**
> Stops silently ignoring failures when persisting refreshed tokens to disk.
> 
> `saveCachedToken` and `saveCachedGraphToken` now catch write errors and emit `console.error` messages (including the EWS `identity` for per-identity caches) to aid debugging when cache writes fail.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7dc5a3bbfd6a988423493d53c12e956f217b9ad4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->