### PR TITLE
fix/issue-44: Add request timeouts to callEws and callGraph

### DIFF
--- a/src/lib/ews-client.ts
+++ b/src/lib/ews-client.ts
@@ -125,9 +125,9 @@ export async function callEws(token: string, envelope: string, mailbox?: string)
     }
     throw err;
   }
-  clearTimeout(timeout);
 
   const xml = await response.text();
+  clearTimeout(timeout);
 
   if (!response.ok) {
     const soapError = extractTag(xml, 'faultstring') || extractTag(xml, 'MessageText');

--- a/src/lib/graph-client.ts
+++ b/src/lib/graph-client.ts
@@ -221,7 +221,6 @@ export async function callGraph<T>(
     }
     throw new GraphApiError(err instanceof Error ? err.message : 'Graph request failed');
   }
-  clearTimeout(timeout);
 
   if (!response.ok) {
     let message = `Graph request failed: HTTP ${response.status}`;
@@ -232,16 +231,21 @@ export async function callGraph<T>(
       code = json.error?.code;
     } catch {
       // Non-JSON error body — throw with HTTP status instead
+      clearTimeout(timeout);
       throw new GraphApiError(message, code, response.status);
     }
+    clearTimeout(timeout);
     throw new GraphApiError(message, code, response.status);
   }
 
   if (!expectJson || response.status === 204) {
+    clearTimeout(timeout);
     return graphResult(undefined as T);
   }
 
-  return graphResult((await response.json()) as T);
+  const result = await response.json();
+  clearTimeout(timeout);
+  return graphResult(result as T);
 }
 
 function buildItemPath(reference?: DriveItemReference): string {


### PR DESCRIPTION
## Summary
Fixes issue #44: `callEws()` and `callGraph()` had no request timeout, causing CLI commands to hang indefinitely on network failure or slow responses.

## Changes
**Files:** `src/lib/ews-client.ts`, `src/lib/graph-client.ts`

- Added `EWS_TIMEOUT_MS` env var (default: 30s) for EWS requests
- Added `GRAPH_TIMEOUT_MS` env var (default: 30s) for Graph API requests
- Both `callEws()` and `callGraph()` now use `AbortController` with the configurable timeout
- On timeout: `GraphApiError` (Graph) or `Error` (EWS) with descriptive message including timeout duration
- Users can override via environment variables: `EWS_TIMEOUT_MS=60000 clippy ...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds `AbortController`-based timeouts to the core `callEws`/`callGraph` request helpers, which can change behavior for slow responses and introduces new timeout-specific errors that callers may need to handle.
> 
> **Overview**
> Prevents indefinite hangs in the core HTTP helpers by adding `AbortController` timeouts to both `callEws()` and `callGraph()`.
> 
> Introduces `EWS_TIMEOUT_MS` and `GRAPH_TIMEOUT_MS` env overrides (default **30s**) and surfaces timeouts as explicit errors (`Error` for EWS; `GraphApiError` with status `408` for Graph), while ensuring timers are cleared on all success/error paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a11742994399c4871b02aca5b5c457271c65ffa1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->