### PR TITLE
fix/issue-43: Dynamic timezone bias + FreeBusyView fallback

### DIFF
--- a/src/lib/ews-client.ts
+++ b/src/lib/ews-client.ts
@@ -82,19 +82,20 @@ function requireNonEmpty(value: string, fieldName: string): string {
  * This dynamically computes the bias based on the current system timezone and date.
  */
 function getLocalTimezoneBias(): number {
+  const year = new Date().getFullYear();
   // Create a date at the start of the year to get the standard (non-DST) offset
-  const jan = new Date(Date.now());
-  const janOffset = -jan.getTimezoneOffset();
+  const jan = new Date(year, 0, 1);
+  const janOffset = jan.getTimezoneOffset();
 
   // Create a date in mid-year (July) to check for DST offset
-  const jul = new Date(Date.now());
-  const julOffset = -jul.getTimezoneOffset();
+  const jul = new Date(year, 6, 1);
+  const julOffset = jul.getTimezoneOffset();
 
-  // Return the minimum (most negative) offset, which is the standard time bias
+  // Return the maximum (most positive) offset, which is the standard time bias
   // For CET/CEST: janOffset = -60, julOffset = -120 → return -60 (standard time)
   // For UTC: both are 0 → return 0
   // For EST/EDT: janOffset = 300 (UTC-5), julOffset = 240 (UTC-4) → return 300 (standard time)
-  return Math.min(janOffset, julOffset);
+  return Math.max(janOffset, julOffset);
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes issue #43 with three improvements:

### 1. Dynamic timezone bias (instead of hardcoded -60)
- Added `getLocalTimezoneBias()` helper that dynamically computes the user's timezone bias
- Added `buildTimeZoneXml()` helper that builds the SOAP TimeZone element with dynamic bias
- Updated `getScheduleViaOutlook()` and `areRoomsFree()` to use dynamic timezone

### 2. FreeBusyView fallback (instead of fake "No available times")
- `getScheduleViaOutlook()` now falls back to actual `FreeBusyView` data when `SuggestionsView` returns no results
- No longer creates fake 'Busy' entries with 'No available times' subject
- Instead, parses `CalendarEvent` blocks from `FreeBusyResponse` to get real free/busy data

### 3. getFreeBusy deprecation documented
- `getFreeBusy()` already only returns the OAuth token owner's calendar (not arbitrary emails)
- Added deprecation JSDoc to clarify this limitation
- For actual free/busy of arbitrary emails, use `getScheduleViaOutlook()`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches EWS availability request/response handling and timezone math; incorrect bias or XML parsing could shift returned slots or misclassify busy/free for some locales/DST transitions.
> 
> **Overview**
> Fixes EWS availability lookups to be timezone-aware and more accurate when suggestions are unavailable.
> 
> Replaces the previously hardcoded EWS `<t:TimeZone>` bias with a dynamically computed bias via new helpers (`getLocalTimezoneBias()`, `buildTimeZoneXml()`) and uses it in `GetUserAvailabilityRequest` calls (`getScheduleViaOutlook`, `areRoomsFree`).
> 
> Changes `getScheduleViaOutlook()` behavior when `SuggestionsView` returns no slots: instead of generating a synthetic all-busy "No available times" block, it parses `FreeBusyResponse/CalendarEvent` entries and returns the overlapping events with mapped `Free`/`Tentative`/`Busy` statuses (UTC timestamps).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9a4b65894863889e46a96a1ec39aff42e6cfb60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->