### PR TITLE
fix: parseTimeToDate throws on invalid time strings

### DIFF
--- a/src/commands/calendar.ts
+++ b/src/commands/calendar.ts
@@ -73,12 +73,12 @@ function getDateRange(startDay: string, endDay?: string): { start: string; end: 
   }
 
   // Single day or start of range
-  const startDate = parseDay(startDay, { weekdayDirection: 'previous', throwOnInvalid: true });
+  const startDate = parseDay(startDay, { weekdayDirection: 'previous' });
   startDate.setHours(0, 0, 0, 0);
 
   if (endDay) {
     // Date range - use nearestForward for end date
-    const endDate = parseDay(endDay, { baseDate: startDate, weekdayDirection: 'nearestForward', throwOnInvalid: true });
+    const endDate = parseDay(endDay, { baseDate: startDate, weekdayDirection: 'nearestForward' });
     endDate.setHours(0, 0, 0, 0);
     // Exclusive end: next day's midnight
     const endExclusive = new Date(endDate);
@@ -218,25 +218,7 @@ export const calendarCommand = new Command('calendar')
         process.exit(1);
       }
 
-      let start: string;
-      let end: string;
-      let label: string;
-
-      try {
-        const range = getDateRange(startDay, endDay);
-        start = range.start;
-        end = range.end;
-        label = range.label;
-      } catch (err) {
-        const message = err instanceof Error ? err.message : 'Invalid date value';
-        if (options.json) {
-          console.log(JSON.stringify({ error: message }, null, 2));
-        } else {
-          console.error(`Error: ${message}`);
-        }
-        process.exit(1);
-      }
-
+      const { start, end, label } = getDateRange(startDay, endDay);
       const result = await getCalendarEvents(authResult.token!, start, end);
 
       if (!result.ok || !result.data) {

--- a/src/commands/counter.ts
+++ b/src/commands/counter.ts
@@ -20,20 +20,29 @@ export const counterCommand = new Command('counter')
 
     // Parse dates and times
     let baseDate: Date;
-    let start: Date;
-    let end: Date;
-
     try {
       baseDate = parseDay(options.day, { throwOnInvalid: true });
-      start = parseTimeToDate(startTime, baseDate);
-      end = parseTimeToDate(endTime, baseDate);
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Invalid date/time value';
-      if (options.json) {
-        console.log(JSON.stringify({ error: message }, null, 2));
-      } else {
-        console.error(`Error: ${message}`);
-      }
+      const message = err instanceof Error ? err.message : 'Invalid day value';
+      console.error(`Error: ${message}`);
+      process.exit(1);
+    }
+
+    let start: Date;
+    try {
+      start = parseTimeToDate(startTime, baseDate, { throwOnInvalid: true });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Invalid start time';
+      console.error(`Error: ${message}`);
+      process.exit(1);
+    }
+
+    let end: Date;
+    try {
+      end = parseTimeToDate(endTime, baseDate, { throwOnInvalid: true });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Invalid end time';
+      console.error(`Error: ${message}`);
       process.exit(1);
     }
 

--- a/src/commands/create-event.ts
+++ b/src/commands/create-event.ts
@@ -134,28 +134,52 @@ export const createEventCommand = new Command('create-event')
 
       // Parse date and times
       let baseDate: Date;
-      let start: Date;
-      let end: Date;
-
       try {
         baseDate = parseDay(options.day, { throwOnInvalid: true });
-        if (options.allDay) {
-          start = new Date(baseDate);
-          start.setHours(0, 0, 0, 0);
-          end = new Date(baseDate);
-          end.setHours(23, 59, 59, 999);
-        } else {
-          start = parseTimeToDate(startTime!, baseDate);
-          end = parseTimeToDate(endTime!, baseDate);
-        }
       } catch (err) {
-        const message = err instanceof Error ? err.message : 'Invalid date/time value';
+        const message = err instanceof Error ? err.message : 'Invalid day value';
         if (options.json) {
           console.log(JSON.stringify({ error: message }, null, 2));
         } else {
           console.error(`Error: ${message}`);
         }
         process.exit(1);
+      }
+
+      let start: Date;
+      let end: Date;
+
+      if (options.allDay) {
+        // For all-day events, use midnight boundaries regardless of provided times
+        start = new Date(baseDate);
+        start.setHours(0, 0, 0, 0);
+        end = new Date(baseDate);
+        end.setHours(23, 59, 59, 999);
+      } else {
+        // For regular events, parse the provided times
+        try {
+          start = parseTimeToDate(startTime!, baseDate, { throwOnInvalid: true });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Invalid start time';
+          if (options.json) {
+            console.log(JSON.stringify({ error: message }, null, 2));
+          } else {
+            console.error(`Error: ${message}`);
+          }
+          process.exit(1);
+        }
+
+        try {
+          end = parseTimeToDate(endTime!, baseDate, { throwOnInvalid: true });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Invalid end time';
+          if (options.json) {
+            console.log(JSON.stringify({ error: message }, null, 2));
+          } else {
+            console.error(`Error: ${message}`);
+          }
+          process.exit(1);
+        }
       }
 
       // Parse attendees

--- a/src/commands/delete-event.ts
+++ b/src/commands/delete-event.ts
@@ -63,18 +63,7 @@ export const deleteEventCommand = new Command('delete-event')
       }
 
       // Get events for the day
-      let baseDate: Date;
-      try {
-        baseDate = parseDay(options.day, { throwOnInvalid: true });
-      } catch (err) {
-        const message = err instanceof Error ? err.message : 'Invalid day value';
-        if (options.json) {
-          console.log(JSON.stringify({ error: message }, null, 2));
-        } else {
-          console.error(`Error: ${message}`);
-        }
-        process.exit(1);
-      }
+      const baseDate = parseDay(options.day);
       const startOfDay = new Date(baseDate);
       startOfDay.setHours(0, 0, 0, 0);
       const endOfDay = new Date(baseDate);
@@ -193,7 +182,7 @@ export const deleteEventCommand = new Command('delete-event')
           try {
             instanceDate = parseDay(options.instance, { throwOnInvalid: true });
           } catch (err) {
-            const message = err instanceof Error ? err.message : 'Invalid day value';
+            const message = err instanceof Error ? err.message : 'Invalid instance date';
             if (options.json) {
               console.log(JSON.stringify({ error: message }, null, 2));
             } else {

--- a/src/commands/update-event.ts
+++ b/src/commands/update-event.ts
@@ -197,7 +197,7 @@ export const updateEventCommand = new Command('update-event')
           try {
             instanceDate = parseDay(options.instance, { throwOnInvalid: true });
           } catch (err) {
-            const message = err instanceof Error ? err.message : 'Invalid day value';
+            const message = err instanceof Error ? err.message : 'Invalid instance date';
             if (options.json) {
               console.log(JSON.stringify({ error: message }, null, 2));
             } else {
@@ -300,24 +300,34 @@ export const updateEventCommand = new Command('update-event')
       if (options.start || options.end) {
         const eventDate = new Date(displayEvent!.Start.DateTime);
 
-        try {
-          if (options.start) {
-            const newStart = parseTimeToDate(options.start, eventDate);
+        if (options.start) {
+          try {
+            const newStart = parseTimeToDate(options.start, eventDate, { throwOnInvalid: true });
             updateOptions.start = toUTCISOString(newStart);
+          } catch (err) {
+            const message = err instanceof Error ? err.message : 'Invalid start time';
+            if (options.json) {
+              console.log(JSON.stringify({ error: message }, null, 2));
+            } else {
+              console.error(`Error: ${message}`);
+            }
+            process.exit(1);
           }
+        }
 
-          if (options.end) {
-            const newEnd = parseTimeToDate(options.end, eventDate);
+        if (options.end) {
+          try {
+            const newEnd = parseTimeToDate(options.end, eventDate, { throwOnInvalid: true });
             updateOptions.end = toUTCISOString(newEnd);
+          } catch (err) {
+            const message = err instanceof Error ? err.message : 'Invalid end time';
+            if (options.json) {
+              console.log(JSON.stringify({ error: message }, null, 2));
+            } else {
+              console.error(`Error: ${message}`);
+            }
+            process.exit(1);
           }
-        } catch (err) {
-          const message = err instanceof Error ? err.message : 'Invalid time value';
-          if (options.json) {
-            console.log(JSON.stringify({ error: message }, null, 2));
-          } else {
-            console.error(`Error: ${message}`);
-          }
-          process.exit(1);
         }
       }
 

--- a/src/lib/dates.test.ts
+++ b/src/lib/dates.test.ts
@@ -11,6 +11,25 @@ describe('dates helpers', () => {
     expect(parseTimeToDate('12am', base).getHours()).toBe(0);
   });
 
+  it('parseTimeToDate throws on invalid input when configured', () => {
+    const base = new Date('2026-03-27T00:00:00');
+    const opts = { throwOnInvalid: true };
+
+    // Format errors
+    expect(() => parseTimeToDate('not-a-time', base, opts)).toThrow('Invalid time format: "not-a-time" — expected HH:MM, H:MM, or H(am|pm)');
+    
+    // Value bounds
+    expect(() => parseTimeToDate('25:00', base, opts)).toThrow('Invalid time: "25:00" — hours must be 0–23 and minutes 0–59');
+    expect(() => parseTimeToDate('9:60', base, opts)).toThrow('Invalid time: "9:60" — hours must be 0–23 and minutes 0–59');
+    
+    // AM/PM bounds
+    expect(() => parseTimeToDate('13pm', base, opts)).toThrow('Invalid time: "13pm" — 12-hour values must be 1–12');
+    expect(() => parseTimeToDate('0am', base, opts)).toThrow('Invalid time: "0am" — 12-hour values must be 1–12');
+    
+    // 24-hour hour-only bounds
+    expect(() => parseTimeToDate('24', base, opts)).toThrow('Invalid time: "24" — 24-hour values must be 0–23');
+  });
+
   it('toUTCISOString formats as UTC with Z suffix', () => {
     const date = new Date(Date.UTC(2026, 2, 27, 9, 5, 7));
     const result = toUTCISOString(date);

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -6,43 +6,56 @@ export interface ParseDayOptions {
   throwOnInvalid?: boolean;
 }
 
-export interface ParseTimeOptions {
+export interface ParseTimeToDateOptions {
   throwOnInvalid?: boolean;
 }
 
-export function parseTimeToDate(timeStr: string, baseDate: Date = new Date(), options: ParseTimeOptions = {}): Date {
-  const { throwOnInvalid = true } = options;
+export function parseTimeToDate(
+  timeStr: string,
+  baseDate: Date = new Date(),
+  options: ParseTimeToDateOptions = {}
+): Date {
+  const { throwOnInvalid = false } = options;
   const result = new Date(baseDate);
 
   const timeMatch = timeStr.match(/^(\d{1,2}):(\d{2})$/);
   if (timeMatch) {
     const hours = parseInt(timeMatch[1], 10);
-    const mins = parseInt(timeMatch[2], 10);
-    if (hours > 23 || mins > 59) {
-      if (throwOnInvalid) throw new Error(`Invalid time value: ${timeStr}`);
-      return result;
+    const minutes = parseInt(timeMatch[2], 10);
+    if (throwOnInvalid && (hours < 0 || hours > 23 || minutes < 0 || minutes > 59)) {
+      throw new Error(`Invalid time: "${timeStr}" — hours must be 0–23 and minutes 0–59`);
     }
-    result.setHours(hours, mins, 0, 0);
+    result.setHours(hours, minutes, 0, 0);
     return result;
   }
 
   const hourMatch = timeStr.match(/^(\d{1,2})(am|pm)?$/i);
   if (hourMatch) {
-    let hour = parseInt(hourMatch[1], 10);
+    const rawHour = parseInt(hourMatch[1], 10);
     const isPM = hourMatch[2]?.toLowerCase() === 'pm';
-
-    if (hour > 23 || (hourMatch[2] && (hour > 12 || hour === 0))) {
-      if (throwOnInvalid) throw new Error(`Invalid time value: ${timeStr}`);
-      return result;
+    if (throwOnInvalid) {
+      if (hourMatch[2]) {
+        if (rawHour < 1 || rawHour > 12) {
+          throw new Error(`Invalid time: "${timeStr}" — 12-hour values must be 1–12`);
+        }
+      } else {
+        if (rawHour < 0 || rawHour > 23) {
+          throw new Error(`Invalid time: "${timeStr}" — 24-hour values must be 0–23`);
+        }
+      }
     }
-
-    if (isPM && hour < 12) hour += 12;
-    if (!isPM && hour === 12) hour = 0;
+    let hour = rawHour;
+    if (hourMatch[2]) {
+      if (isPM && rawHour < 12) hour += 12;
+      if (!isPM && rawHour === 12) hour = 0;
+    }
     result.setHours(hour, 0, 0, 0);
     return result;
   }
 
-  if (throwOnInvalid) throw new Error(`Invalid time format: ${timeStr}`);
+  if (throwOnInvalid) {
+    throw new Error(`Invalid time format: "${timeStr}" — expected HH:MM, H:MM, or H(am|pm)`);
+  }
   return result;
 }
 

--- a/src/lib/ews-client.ts
+++ b/src/lib/ews-client.ts
@@ -2496,18 +2496,32 @@ export async function areRoomsFree(
       </t:FreeBusyViewOptions>
     </m:GetUserAvailabilityRequest>`);
 
-      const response = await fetch(EWS_ENDPOINT, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'text/xml; charset=utf-8',
-          Accept: 'text/xml',
-          'X-AnchorMailbox': EWS_USERNAME
-        },
-        body: envelope
-      });
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), EWS_TIMEOUT_MS);
 
-      const xml = await response.text();
+      let response: Response;
+      let xml: string;
+      try {
+        response = await fetch(EWS_ENDPOINT, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'text/xml; charset=utf-8',
+            Accept: 'text/xml',
+            'X-AnchorMailbox': EWS_USERNAME
+          },
+          body: envelope,
+          signal: controller.signal
+        });
+        xml = await response.text();
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') {
+          throw new Error(`EWS request timed out after ${EWS_TIMEOUT_MS / 1000}s`);
+        }
+        throw err;
+      } finally {
+        clearTimeout(timeout);
+      }
 
       if (!response.ok) {
         const soapError = extractTag(xml, 'faultstring') || extractTag(xml, 'MessageText');


### PR DESCRIPTION
Replaced old PR #176 — branched from dev. Fixes #45

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes date/time parsing defaults and how multiple CLI commands validate inputs, which can alter behavior for previously-accepted invalid strings. Adds a timeout path to an EWS availability request, which could surface new errors under slow network conditions.
> 
> **Overview**
> **Improves robustness of CLI date/time handling.** `parseTimeToDate` is updated to be non-throwing by default and, when `throwOnInvalid` is enabled, to emit more specific validation errors (format vs bounds) with new test coverage.
> 
> Commands that accept time inputs (`create-event`, `update-event`, `counter`) now opt into strict parsing and report clearer, field-specific errors (invalid day/start/end). Calendar range parsing is simplified by removing the local try/catch, and `delete-event` no longer forces strict `parseDay` for the base `--day`.
> 
> **Hardens EWS room availability calls.** `areRoomsFree` now uses an `AbortController` with `EWS_TIMEOUT_MS` to fail fast on hung requests and return a descriptive timeout error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f87b0c5bb41bbf9ba87223a9e19655aeecfa7983. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->