### PR TITLE
fix: createLargeUploadSession actually uploads the file

### DIFF
--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { resolveGraphAuth } from '../lib/graph-auth.js';
 import {
   checkinFile,
+  uploadLargeFile,
   createOfficeCollaborationLink,
   type DriveItem,
   type DriveItemReference,
@@ -154,6 +155,41 @@ filesCommand
     console.log(`✓ Uploaded: ${result.data.name}`);
     console.log(`  ID: ${result.data.id}`);
     if (result.data.webUrl) console.log(`  URL: ${result.data.webUrl}`);
+  });
+
+filesCommand
+  .command('upload-large <path>')
+  .description('Upload a file up to 4GB using a chunked upload session')
+  .option('--folder <id>', 'Target folder item ID')
+  .option('--json', 'Output as JSON')
+  .option('--token <token>', 'Use a specific Graph token')
+  .action(async (path: string, options: { folder?: string; json?: boolean; token?: string }) => {
+    const auth = await resolveGraphAuth({ token: options.token });
+    if (!auth.success) {
+      console.error(`Error: ${auth.error}`);
+      process.exit(1);
+    }
+
+    const result = await uploadLargeFile(auth.token!, path, parseFolderRef(options.folder));
+    if (!result.ok || !result.data) {
+      console.error(`Error: ${result.error?.message || 'Failed to upload file'}`);
+      process.exit(1);
+    }
+
+    if (options.json) {
+      console.log(JSON.stringify(result.data, null, 2));
+      return;
+    }
+
+    if (result.data.driveItem) {
+      console.log(`✓ Uploaded: ${result.data.driveItem.name}`);
+      console.log(`  ID: ${result.data.driveItem.id}`);
+      if (result.data.driveItem.webUrl) console.log(`  URL: ${result.data.driveItem.webUrl}`);
+    } else {
+      console.log('✓ Large upload session created');
+      console.log(`  Upload URL: ${result.data.uploadUrl}`);
+      if (result.data.expirationDateTime) console.log(`  Expires: ${result.data.expirationDateTime}`);
+    }
   });
 
 filesCommand

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,12 +95,14 @@ export type {
   GraphError,
   GraphResponse,
   OfficeCollabLinkResult,
-  SharingLinkResult
+  SharingLinkResult,
+  UploadLargeResult
 } from './lib/graph-client.js';
 export {
   checkinFile,
   checkoutFile,
   cleanupDownloadedFile,
+  uploadLargeFile,
   createOfficeCollaborationLink,
   defaultDownloadPath,
   deleteFile,

--- a/src/lib/graph-client.test.ts
+++ b/src/lib/graph-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it, afterEach } from 'bun:test';
 
 const token = 'test-token';
 const baseUrl = 'https://graph.microsoft.com/v1.0';
@@ -25,6 +25,69 @@ describe('searchFiles query encoding', () => {
       expect(fetchCalls).toHaveLength(1);
       expect(fetchCalls[0]).toContain("/me/drive/root/search(q='%27%29%20and%20name%3D%27anything')");
       expect(fetchCalls[0]).not.toContain("q=') and name='anything'");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+
+import { unlink, writeFile } from 'node:fs/promises';
+import { uploadLargeFile } from './graph-client.js';
+
+describe('uploadLargeFile chunking', () => {
+  const tmpFile = 'test-upload-large.tmp';
+
+  afterEach(async () => {
+    try { await unlink(tmpFile); } catch {}
+  });
+
+  it('uploads file in chunks and returns DriveItem', async () => {
+    const fileSize = 25 * 1024 * 1024; // 25MB
+    const buffer = new Uint8Array(fileSize);
+    buffer.fill(42);
+    await writeFile(tmpFile, buffer);
+
+    const originalFetch = globalThis.fetch;
+    const fetchCalls = [];
+
+    try {
+      globalThis.fetch = (async (input, init) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        
+        // 1. Create session POST
+        if (url.includes('createUploadSession')) {
+          return new Response(JSON.stringify({
+            uploadUrl: 'https://upload.example.com/session-123',
+            expirationDateTime: '2026-04-01T00:00:00.000Z'
+          }), { status: 200, headers: { 'content-type': 'application/json' } });
+        }
+
+        // 2. Chunk PUTs
+        if (init?.method === 'PUT') {
+          fetchCalls.push({ url, range: init.headers['Content-Range'], bodySize: init.body.length });
+          const range = init.headers['Content-Range'];
+          if (range.startsWith('bytes 20971520-26214399')) { // Last chunk 10MB*2 to 25MB
+            return new Response(JSON.stringify({ id: 'item-123', name: 'test.tmp' }), {
+              status: 201, headers: { 'content-type': 'application/json' }
+            });
+          }
+          return new Response('{"expirationDateTime": "..."}', { status: 202 });
+        }
+        
+        return new Response('{}', { status: 200 });
+      });
+
+      const result = await uploadLargeFile('token', tmpFile);
+
+      expect(result.ok).toBe(true);
+      expect(result.data?.driveItem?.id).toBe('item-123');
+      expect(fetchCalls.length).toBe(3);
+      expect(fetchCalls[0].range).toBe('bytes 0-10485759/26214400');
+      expect(fetchCalls[1].range).toBe('bytes 10485760-20971519/26214400');
+      expect(fetchCalls[2].range).toBe('bytes 20971520-26214399/26214400');
+      expect(fetchCalls[2].bodySize).toBe(5 * 1024 * 1024);
+
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/src/lib/graph-client.ts
+++ b/src/lib/graph-client.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from 'node:crypto';
 import { createReadStream, createWriteStream } from 'node:fs';
-import { mkdir, rename, stat, unlink } from 'node:fs/promises';
+import { mkdir, open, rename, stat, unlink } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { basename, dirname, resolve } from 'node:path';
 import { Readable } from 'node:stream';
@@ -289,6 +289,12 @@ export async function getFileMetadata(token: string, itemId: string): Promise<Gr
   }
 }
 
+export interface UploadLargeResult {
+  uploadUrl: string;
+  expirationDateTime?: string;
+  driveItem?: DriveItem;
+}
+
 export async function uploadFile(
   token: string,
   localPath: string,
@@ -322,6 +328,156 @@ export async function uploadFile(
       return graphError(err instanceof Error ? err.message : 'Upload failed');
     } finally {
       stream.destroy();
+    }
+  } catch (err) {
+    return graphError(err instanceof Error ? err.message : 'Upload failed');
+  }
+}
+
+export async function uploadLargeFile(
+  token: string,
+  localPath: string,
+  folder?: DriveItemReference
+): Promise<GraphResponse<UploadLargeResult>> {
+  try {
+    const absolutePath = resolve(localPath);
+    const fileStats = await stat(absolutePath);
+    if (!fileStats.isFile()) return graphError(`Not a file: ${absolutePath}`);
+    if (fileStats.size > 4 * 1024 * 1024 * 1024) {
+      return graphError('File exceeds 4GB large upload limit.');
+    }
+
+    const fileName = basename(absolutePath);
+    const folderPath = folder?.id ? `${buildItemPath(folder)}:/` : '/me/drive/root:/';
+
+    // Step 1: Create the upload session
+    let sessionResult: GraphResponse<UploadLargeResult>;
+    try {
+      sessionResult = await callGraph<UploadLargeResult>(
+        token,
+        `${folderPath}${encodeURIComponent(fileName)}:/createUploadSession`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ item: { '@microsoft.graph.conflictBehavior': 'replace', name: fileName } })
+        }
+      );
+    } catch (err) {
+      if (err instanceof GraphApiError) {
+        return graphError(err.message, err.code, err.status);
+      }
+      return graphError(err instanceof Error ? err.message : 'Failed to create upload session');
+    }
+
+    if (!sessionResult.ok || !sessionResult.data) {
+      return sessionResult;
+    }
+
+    const { uploadUrl, expirationDateTime } = sessionResult.data;
+
+    // Step 2: Upload the file in chunks
+    const fileSize = fileStats.size;
+
+    if (fileSize === 0) {
+      return graphError('Cannot upload zero-byte files using large upload session. Use simple upload instead.');
+    }
+
+    const CHUNK_SIZE = 10 * 1024 * 1024; // 10MB chunks
+    const fileHandle = await open(absolutePath, 'r');
+    const chunkBuffer = new Uint8Array(CHUNK_SIZE);
+
+    try {
+      let offset = 0;
+      let lastSuccessfulResponse: Response | null = null;
+
+      while (offset < fileSize) {
+        const chunkLength = Math.min(CHUNK_SIZE, fileSize - offset);
+        const { bytesRead } = await fileHandle.read(chunkBuffer, 0, chunkLength, offset);
+
+        if (bytesRead === 0) break;
+
+        const endOffset = offset + bytesRead - 1;
+        const contentRange = `bytes ${offset}-${endOffset}/${fileSize}`;
+        const chunkData = chunkBuffer.subarray(0, bytesRead);
+
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), GRAPH_TIMEOUT_MS);
+
+        try {
+          lastSuccessfulResponse = await fetch(uploadUrl, {
+            method: 'PUT',
+            headers: {
+              'Content-Length': String(bytesRead),
+              'Content-Range': contentRange
+            },
+            body: chunkData,
+            signal: controller.signal,
+            redirect: 'manual'
+          });
+        } catch (err: any) {
+          if (err && err.name === 'AbortError') {
+            return graphError(
+              `Chunk upload timed out after ${GRAPH_TIMEOUT_MS} ms at offset ${offset}`,
+              'RequestTimeout',
+              408
+            );
+          }
+          throw err;
+        } finally {
+          clearTimeout(timeoutId);
+        }
+
+        if (!lastSuccessfulResponse.ok) {
+          const errorBody = await lastSuccessfulResponse.text().catch(() => '');
+          return graphError(
+            `Chunk upload failed at offset ${offset} (HTTP ${lastSuccessfulResponse.status}): ${errorBody}`,
+            String(lastSuccessfulResponse.status),
+            lastSuccessfulResponse.status
+          );
+        }
+
+        offset += bytesRead;
+
+        if (offset < fileSize) {
+          await lastSuccessfulResponse.text().catch(() => {});
+        }
+      }
+
+      if (offset !== fileSize) {
+        return graphError(`Upload stopped early. Expected to upload ${fileSize} bytes but uploaded ${offset}`);
+      }
+
+      // Step 3: Parse the final response
+      if (lastSuccessfulResponse) {
+        const status = lastSuccessfulResponse.status;
+        if (status === 200 || status === 201) {
+          let body: unknown;
+          try {
+            body = await lastSuccessfulResponse.json();
+          } catch {
+            return graphError('Upload completed but failed to parse final response');
+          }
+
+          const maybeDriveItem = body as Partial<DriveItem> | null;
+          if (
+            maybeDriveItem &&
+            typeof maybeDriveItem === 'object' &&
+            typeof maybeDriveItem.id === 'string' &&
+            typeof maybeDriveItem.name === 'string'
+          ) {
+            const driveItem = maybeDriveItem as DriveItem;
+            return {
+              ok: true,
+              data: { uploadUrl, expirationDateTime, driveItem }
+            };
+          }
+
+          return graphError('Upload completed but final response did not contain drive item metadata');
+        }
+      }
+
+      return graphError('Upload completed but final response was not valid');
+    } finally {
+      await fileHandle.close();
     }
   } catch (err) {
     return graphError(err instanceof Error ? err.message : 'Upload failed');


### PR DESCRIPTION
Replaced old PR #172 — branched from dev. Fixes #46

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new chunked upload logic that performs multi-request PUTs to Graph upload sessions and new CLI surface area; failures/timeouts or partial uploads could impact reliability for large transfers.
> 
> **Overview**
> Adds support for OneDrive *large* uploads by introducing `uploadLargeFile` (up to 4GB) that creates an upload session and streams the file in 10MB chunks with per-chunk timeouts and final DriveItem parsing.
> 
> Exposes this via a new CLI command `files upload-large <path>` and exports `uploadLargeFile`/`UploadLargeResult` from the library API. Adds a unit test that mocks `fetch` to verify chunk ranges and successful completion behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d24fd2f1d62ebf69c78a73376993f63d3a4f8c14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->