### PR TITLE
feat: Add file version history & restore

### DIFF
--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -13,7 +13,10 @@ import {
   searchFiles,
   shareFile,
   uploadFile,
-  uploadLargeFile
+  uploadLargeFile,
+  listFileVersions,
+  restoreFileVersion,
+  type DriveItemVersion
 } from '../lib/graph-client.js';
 
 function parseFolderRef(folder?: string): DriveItemReference | undefined {
@@ -321,6 +324,69 @@ filesCommand
       if (result.data.id) console.log(`  Link ID: ${result.data.id}`);
     }
   );
+
+
+filesCommand
+  .command('versions <fileId>')
+  .description('List versions of a file')
+  .option('--json', 'Output as JSON')
+  .option('--token <token>', 'Use a specific Graph token')
+  .action(async (fileId: string, options: { json?: boolean; token?: string }) => {
+    const auth = await resolveGraphAuth({ token: options.token });
+    if (!auth.success) {
+      console.error(`Error: ${auth.error}`);
+      process.exit(1);
+    }
+
+    const result = await listFileVersions(auth.token!, fileId);
+    if (!result.ok || !result.data) {
+      console.error(`Error: ${result.error?.message || 'Failed to list versions'}`);
+      process.exit(1);
+    }
+
+    if (options.json) {
+      console.log(JSON.stringify({ versions: result.data }, null, 2));
+      return;
+    }
+
+    if (result.data.length === 0) {
+      console.log('No versions found.');
+      return;
+    }
+
+    for (const v of result.data) {
+      console.log(`VERSION  ${v.id}`);
+      if (v.lastModifiedDateTime) console.log(`      Modified: ${v.lastModifiedDateTime}`);
+      if (v.size !== undefined) console.log(`      Size:     ${formatBytes(v.size)}`);
+      if (v.lastModifiedBy?.user?.displayName) console.log(`      By:       ${v.lastModifiedBy.user.displayName}`);
+    }
+  });
+
+filesCommand
+  .command('restore <fileId> <versionId>')
+  .description('Restore a specific version of a file')
+  .option('--json', 'Output as JSON')
+  .option('--token <token>', 'Use a specific Graph token')
+  .action(async (fileId: string, versionId: string, options: { json?: boolean; token?: string }) => {
+    const auth = await resolveGraphAuth({ token: options.token });
+    if (!auth.success) {
+      console.error(`Error: ${auth.error}`);
+      process.exit(1);
+    }
+
+    const result = await restoreFileVersion(auth.token!, fileId, versionId);
+    if (!result.ok) {
+      console.error(`Error: ${result.error?.message || 'Restore failed'}`);
+      process.exit(1);
+    }
+
+    if (options.json) {
+      console.log(JSON.stringify({ success: true, fileId, versionId }, null, 2));
+      return;
+    }
+
+    console.log(`✓ Restored version ${versionId} of file ${fileId}`);
+  });
 
 filesCommand
   .command('checkin <fileId>')

--- a/src/lib/graph-client.ts
+++ b/src/lib/graph-client.ts
@@ -52,7 +52,16 @@ export interface DriveItem {
   '@microsoft.graph.downloadUrl'?: string;
 }
 
+
+export interface DriveItemVersion {
+  id: string;
+  lastModifiedDateTime?: string;
+  size?: number;
+  lastModifiedBy?: { user?: { displayName?: string; email?: string } };
+}
+
 export interface DriveItemListResponse {
+
   value: DriveItem[];
 }
 
@@ -770,6 +779,27 @@ export async function createOfficeCollaborationLink(
 
 export function defaultDownloadPath(fileName: string): string {
   return resolve(homedir(), 'Downloads', basename(fileName));
+}
+
+
+export async function listFileVersions(token: string, itemId: string): Promise<GraphResponse<DriveItemVersion[]>> {
+  return fetchAllPages<DriveItemVersion>(token, `/me/drive/items/${encodeURIComponent(itemId)}/versions`, 'Failed to list versions');
+}
+
+export async function restoreFileVersion(token: string, itemId: string, versionId: string): Promise<GraphResponse<void>> {
+  try {
+    return await callGraph<void>(
+      token,
+      `/me/drive/items/${encodeURIComponent(itemId)}/versions/${encodeURIComponent(versionId)}/restoreVersion`,
+      { method: 'POST' },
+      false
+    );
+  } catch (err) {
+    if (err instanceof GraphApiError) {
+      return graphError(err.message, err.code, err.status);
+    }
+    return graphError(err instanceof Error ? err.message : 'Failed to restore version');
+  }
 }
 
 export async function cleanupDownloadedFile(path: string): Promise<void> {


### PR DESCRIPTION
Adds file version history listing and restoration via Microsoft Graph API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Graph API operations to restore prior file versions, which can overwrite current file content if misused. Scope is limited to CLI commands and new client wrappers, but touches write operations against user data.
> 
> **Overview**
> Adds OneDrive file version history support to the CLI.
> 
> Introduces `files versions <fileId>` to list available versions (human-readable or `--json`) and `files restore <fileId> <versionId>` to restore a selected version. The Graph client gains a `DriveItemVersion` type plus `listFileVersions` (paged `/versions` fetch) and `restoreFileVersion` (POST `.../restoreVersion`) helpers with standard error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3765edf0ed47d5c7e1db78564e8ff6d66fb59026. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->