### PR TITLE
feat: Follow-up Flags & Sensitivity Labels

### DIFF
--- a/src/commands/create-event.ts
+++ b/src/commands/create-event.ts
@@ -8,7 +8,8 @@ import {
   type Recurrence,
   type RecurrencePattern,
   type RecurrenceRange,
-  searchRooms
+  searchRooms,
+  SENSITIVITY_MAP
 } from '../lib/ews-client.js';
 
 function formatTime(dateStr: string): string {
@@ -339,13 +340,7 @@ export const createEventCommand = new Command('create-event')
         recurrence = { Pattern: pattern, Range: range };
       }
 
-      const sensitivityMap: Record<string, 'Normal' | 'Personal' | 'Private' | 'Confidential'> = {
-        normal: 'Normal',
-        personal: 'Personal',
-        private: 'Private',
-        confidential: 'Confidential'
-      };
-      const sensitivity = options.sensitivity ? sensitivityMap[options.sensitivity.toLowerCase()] : undefined;
+      const sensitivity = options.sensitivity ? SENSITIVITY_MAP[options.sensitivity.toLowerCase()] : undefined;
 
       if (options.sensitivity && !sensitivity) {
         console.error(`Invalid sensitivity: ${options.sensitivity}`);

--- a/src/commands/mail.ts
+++ b/src/commands/mail.ts
@@ -12,7 +12,8 @@ import {
   moveEmail,
   replyToEmail,
   replyToEmailDraft,
-  updateEmail
+  updateEmail,
+  SENSITIVITY_MAP
 } from '../lib/ews-client.js';
 import { markdownToHtml } from '../lib/markdown.js';
 
@@ -407,13 +408,7 @@ export const mailCommand = new Command('mail')
       // Handle sensitivity
       if (options.sensitivity) {
         const id = options.sensitivity.trim();
-        const levelMap: Record<string, 'Normal' | 'Personal' | 'Private' | 'Confidential'> = {
-          normal: 'Normal',
-          personal: 'Personal',
-          private: 'Private',
-          confidential: 'Confidential'
-        };
-        const sensitivity = levelMap[(options.level || 'normal').toLowerCase()];
+        const sensitivity = SENSITIVITY_MAP[(options.level || 'normal').toLowerCase()];
 
         if (!sensitivity) {
           console.error(`Invalid sensitivity level: ${options.level}`);

--- a/src/commands/update-event.ts
+++ b/src/commands/update-event.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import { resolveAuth } from '../lib/auth.js';
 import { parseDay, parseTimeToDate, toLocalUnzonedISOString, toUTCISOString } from '../lib/dates.js';
-import { getCalendarEvents, getRooms, searchRooms, updateEvent } from '../lib/ews-client.js';
+import { getCalendarEvents, getRooms, searchRooms, updateEvent, SENSITIVITY_MAP } from '../lib/ews-client.js';
 
 function formatTime(dateStr: string): string {
   const date = new Date(dateStr);
@@ -352,13 +352,7 @@ export const updateEventCommand = new Command('update-event')
       }
 
       if (options.sensitivity) {
-        const sensitivityMap: Record<string, 'Normal' | 'Personal' | 'Private' | 'Confidential'> = {
-          normal: 'Normal',
-          personal: 'Personal',
-          private: 'Private',
-          confidential: 'Confidential'
-        };
-        const sensitivity = sensitivityMap[options.sensitivity.toLowerCase()];
+        const sensitivity = SENSITIVITY_MAP[options.sensitivity.toLowerCase()];
         if (!sensitivity) {
           console.error(`Invalid sensitivity: ${options.sensitivity}`);
           process.exit(1);

--- a/src/lib/ews-client.ts
+++ b/src/lib/ews-client.ts
@@ -177,6 +177,13 @@ export interface CalendarAttendee {
   };
 }
 
+export const SENSITIVITY_MAP: Record<string, 'Normal' | 'Personal' | 'Private' | 'Confidential'> = {
+  normal: 'Normal',
+  personal: 'Personal',
+  private: 'Private',
+  confidential: 'Confidential'
+};
+
 export interface CalendarEvent {
   Sensitivity?: 'Normal' | 'Personal' | 'Private' | 'Confidential';
   Id: string;
@@ -1010,7 +1017,8 @@ export async function createEvent(options: CreateEventOptions): Promise<OwaRespo
       recurrence,
       isAllDay,
       mailbox,
-      timezone
+      timezone,
+      sensitivity
     } = options;
 
     let attendeesXml = '';
@@ -1056,7 +1064,7 @@ export async function createEvent(options: CreateEventOptions): Promise<OwaRespo
       <m:Items>
         <t:CalendarItem>
           <t:Subject>${xmlEscape(subject)}</t:Subject>
-          ${options.sensitivity ? `<t:Sensitivity>${xmlEscape(options.sensitivity)}</t:Sensitivity>` : ''}
+          ${sensitivity ? `<t:Sensitivity>${xmlEscape(sensitivity)}</t:Sensitivity>` : ''}
           ${body ? `<t:Body BodyType="Text">${xmlEscape(body)}</t:Body>` : ''}
           <t:Start>${xmlEscape(start)}</t:Start>
           <t:End>${xmlEscape(end)}</t:End>


### PR DESCRIPTION
Adds detailed Follow-up flags (due dates, start dates) and Sensitivity labels (normal, personal, private, confidential) to `update-event`, `create-event`, and `mail`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new EWS fields (`item:Sensitivity`, `item:Flag` start/due dates) to create/update flows; incorrect XML or value mapping could cause Exchange update failures for calendar/mail operations.
> 
> **Overview**
> Adds **Sensitivity labels** across CLI commands: `create-event` and `update-event` accept `--sensitivity` (normal/personal/private/confidential), validate via shared `SENSITIVITY_MAP`, and send `item:Sensitivity` in the EWS SOAP for create/update.
> 
> Extends **mail follow-up flags** so `clippy mail --flag` can optionally set `--start-date` and `--due`, wiring these through `updateEmail` to emit `item:Flag` with `StartDate`/`DueDate`, and adds a new `clippy mail --sensitivity <id> --level <level>` action to update message sensitivity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e288f83a35e10d8a87564d9b41d536a042e93d97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->