### PR TITLE
docs: update README and SKILL for new M365 features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Clippy
 
-A command-line interface for Microsoft 365 using Exchange Web Services (EWS) and Microsoft Graph. Manage your calendar, email, and OneDrive files directly from the terminal.
+A command-line interface for Microsoft 365 using Exchange Web Services (EWS) and Microsoft Graph. Manage your calendar, email, OneDrive files, Microsoft Planner tasks, and SharePoint Sites directly from the terminal.
 
 ## Installation
 
@@ -57,6 +57,9 @@ Or pass `--mailbox` per-command (see examples below).
 ```bash
 # Check who you're logged in as
 clippy whoami
+
+# Verify your Graph API token scopes
+clippy verify-token
 ```
 
 ---
@@ -120,6 +123,9 @@ clippy create-event "Project Review" 14:00 15:00 \
 # Specify a timezone explicitly
 clippy create-event "Global Sync" 09:00 10:00 --timezone "Pacific Standard Time"
 
+# All-day event with category and sensitivity
+clippy create-event "Holiday" --all-day --category "Personal" --sensitivity private
+
 # Find an available room automatically
 clippy create-event "Workshop" 10:00 12:00 --find-room
 
@@ -167,6 +173,8 @@ clippy update-event --id <eventId> --room "Room B"
 clippy update-event --id <eventId> --location "Off-site"
 clippy update-event --id <eventId> --teams        # Add Teams meeting
 clippy update-event --id <eventId> --no-teams      # Remove Teams meeting
+clippy update-event --id <eventId> --all-day       # Make all-day
+clippy update-event --id <eventId> --sensitivity private
 
 # Show events from a specific day
 clippy update-event --day tomorrow
@@ -351,6 +359,10 @@ clippy mail --mark-unread 2
 clippy mail --flag 1
 clippy mail --unflag 2
 clippy mail --complete 3    # Mark flag as complete
+clippy mail --flag 1 --start-date 2026-05-01 --due 2026-05-05
+
+# Set sensitivity
+clippy mail --sensitivity <emailId> --level confidential
 
 # Move to folder (--to here is for folder destination, not email recipient)
 clippy mail --move 1 --to archive
@@ -425,6 +437,13 @@ clippy files search "budget 2026"
 
 # Inspect metadata
 clippy files meta <fileId>
+
+# Get file analytics
+clippy files analytics <fileId>
+
+# File versions
+clippy files versions <fileId>
+clippy files restore <fileId> <versionId>
 ```
 
 ### Upload, Download, Delete, and Share
@@ -443,6 +462,9 @@ clippy files upload-large ./backup.zip --folder <folderId>
 # Download a file
 clippy files download <fileId>
 clippy files download <fileId> --out ./local-copy.docx
+
+# Convert and download (e.g., to PDF)
+clippy files convert <fileId> --format pdf --out ./converted.pdf
 
 # Delete a file
 clippy files delete <fileId>
@@ -486,6 +508,66 @@ Legacy Office formats such as `.doc`, `.xls`, and `.ppt` must be converted first
 
 ---
 
+---
+
+## Microsoft Planner Commands
+
+Manage tasks and plans in Microsoft Planner.
+
+```bash
+# List tasks assigned to you
+clippy planner list-my-tasks
+
+# List your plans
+clippy planner list-plans
+clippy planner list-plans -g <groupId>
+
+# View plan structure
+clippy planner list-buckets --plan <planId>
+clippy planner list-tasks --plan <planId>
+
+# Create and update tasks
+clippy planner create-task --plan <planId> --title "New Task" -b <bucketId>
+clippy planner update-task <taskId> --title "Updated Task" --percent 50 --assign <userId>
+```
+
+---
+
+## SharePoint Commands
+
+Manage SharePoint lists and Site Pages.
+
+### SharePoint Lists (`clippy sharepoint` or `clippy sp`)
+
+```bash
+# List all SharePoint lists in a site
+clippy sp lists --site-id <siteId>
+
+# Get items from a list
+clippy sp items --site-id <siteId> --list-id <listId>
+
+# Create and update items
+clippy sp create-item --site-id <siteId> --list-id <listId> --fields '{"Title": "New Item"}'
+clippy sp update-item --site-id <siteId> --list-id <listId> --item-id <itemId> --fields '{"Title": "Updated Item"}'
+```
+
+### SharePoint Site Pages (`clippy pages`)
+
+```bash
+# List site pages
+clippy pages list <siteId>
+
+# Get a site page
+clippy pages get <siteId> <pageId>
+
+# Update a site page
+clippy pages update <siteId> <pageId> --title "New Title" --name "new-name.aspx"
+
+# Publish a site page
+clippy pages publish <siteId> <pageId>
+```
+
+---
 ## People & Room Search
 
 ```bash

--- a/SKILL/SKILL.md
+++ b/SKILL/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clippy
-description: Microsoft 365 / Outlook CLI using EWS SOAP API + OAuth2. Manage calendar (view, create, update, delete events, find meeting times, respond to invitations), send/read/search email, shared mailbox support, and OneDrive file operations via Microsoft Graph.
+description: Microsoft 365 / Outlook CLI using EWS SOAP API + OAuth2. Manage calendar, send/read/search email, access shared mailboxes, manage OneDrive files, work with Microsoft Planner tasks, and interact with SharePoint Lists & Site Pages via Microsoft Graph and EWS.
 metadata: {"clawdbot":{"requires":{"bins":["clippy"]}}}
 ---
 
@@ -42,7 +42,7 @@ Or pass `--mailbox` per-command on any mail or calendar command.
 
 Check auth: `clippy whoami`
 
-## Commands (13 total)
+## Commands
 
 ---
 
@@ -76,9 +76,11 @@ clippy create-event "Sync" 14:00 15:00 --repeat weekly --days mon,wed,fri
 clippy create-event "Monthly" 10:00 11:00 --repeat monthly --count 10
 clippy create-event "Sprint" 09:00 11:00 --repeat weekly --every 2 --until 2026-12-31
 clippy create-event "Team Standup" 09:00 09:30 --mailbox shared@co.com
+clippy create-event "Holiday" --all-day
+clippy create-event "Private Sync" 10:00 11:00 --sensitivity private --category "Work"
 ```
 
-Options: `--day`, `--timezone`, `--description`, `--attendees`, `--room`, `--teams`, `--list-rooms`, `--find-room`, `--repeat` (daily|weekly|monthly|yearly), `--every`, `--days`, `--until`, `--count`, `--json`, `--token`, `--mailbox`, `--category`, `--clear-categories`, `--sensitivity`, `--all-day`
+Options: `--day`, `--timezone`, `--description`, `--attendees`, `--room`, `--teams`, `--list-rooms`, `--find-room`, `--repeat` (daily|weekly|monthly|yearly), `--every`, `--days`, `--until`, `--count`, `--json`, `--token`, `--mailbox`, `--category`, `--sensitivity`, `--all-day`
 
 #### `clippy update-event [eventIndex]`
 Update a calendar event by index or stable ID.
@@ -91,11 +93,13 @@ clippy update-event --id <eventId> --room "Room B"
 clippy update-event --id <eventId> --location "Off-site"
 clippy update-event --id <eventId> --teams       # add Teams meeting
 clippy update-event --id <eventId> --no-teams    # remove Teams meeting
+clippy update-event --id <eventId> --all-day
+clippy update-event --id <eventId> --sensitivity private
 clippy update-event --day tomorrow               # list events to pick from
 clippy update-event --id <eventId> --mailbox shared@co.com
 ```
 
-Options: `--id`, `--day`, `--timezone`, `--title`, `--description`, `--start`, `--end`, `--add-attendee`, `--room`, `--location`, `--teams`, `--no-teams`, `--json`, `--token`, `--mailbox`, `--category`, `--clear-categories`, `--sensitivity`, `--all-day`
+Options: `--id`, `--day`, `--timezone`, `--title`, `--description`, `--start`, `--end`, `--add-attendee`, `--room`, `--location`, `--teams`, `--no-teams`, `--json`, `--token`, `--mailbox`, `--category`, `--sensitivity`, `--all-day`, `--no-all-day`
 
 #### `clippy delete-event [eventIndex]`
 Delete/cancel a calendar event.
@@ -161,6 +165,8 @@ clippy mail --mark-unread 2
 clippy mail --flag 1
 clippy mail --unflag 2
 clippy mail --complete 3                 # mark flag as complete
+clippy mail --flag 1 --start-date 2026-05-01 --due 2026-05-05
+clippy mail --sensitivity <emailId> --level confidential
 clippy mail --move 1 --to archive        # move to folder
 clippy mail --mailbox shared@co.com      # shared mailbox inbox
 ```
@@ -178,7 +184,7 @@ clippy mail --reply-all 1 --message "..." --mailbox shared@co.com
 clippy mail --forward 1 --to-addr "colleague@co.com" --mailbox shared@co.com
 ```
 
-Options: `-n/--limit`, `-p/--page`, `--unread`, `--flagged`, `-s/--search`, `-r/--read`, `-d/--download`, `-o/--output`, `--mark-read`, `--mark-unread`, `--flag`, `--unflag`, `--complete`, `--move`, `--to`, `--reply`, `--reply-all`, `--draft`, `--forward`, `--to-addr`, `--message`, `--markdown`, `--json`, `--token`, `--mailbox`
+Options: `-n/--limit`, `-p/--page`, `--unread`, `--flagged`, `-s/--search`, `-r/--read`, `-d/--download`, `-o/--output`, `--mark-read`, `--mark-unread`, `--flag`, `--start-date`, `--due`, `--unflag`, `--complete`, `--move`, `--to`, `--reply`, `--reply-all`, `--draft`, `--forward`, `--to-addr`, `--message`, `--markdown`, `--json`, `--token`, `--mailbox`, `--sensitivity`, `--level`
 
 #### `clippy send`
 Send an email. **`--body` is optional** — allows sending a subject-only or even empty email.
@@ -291,6 +297,14 @@ Options: `--type` (view|edit), `--scope` (org|anonymous), `--collab`, `--lock`, 
 #### `clippy files checkin <fileId>`
 ```
 clippy files checkin <fileId> --comment "Updated Q1 numbers"
+
+# File Versions & Restore
+clippy files versions <fileId>
+clippy files restore <fileId> <versionId>
+
+# Analytics & Conversion
+clippy files analytics <fileId>
+clippy files convert <fileId> --format pdf --out ./converted.pdf
 ```
 
 ---
@@ -305,6 +319,51 @@ clippy find "smith" --people
 ```
 
 Options: `--rooms`, `--people`, `--json`, `--token`
+
+---
+
+---
+
+### Microsoft Planner (`clippy planner`)
+
+Manage tasks and plans in Microsoft Planner.
+
+```bash
+clippy planner list-my-tasks                 # Tasks assigned to you
+clippy planner list-plans                    # List your plans
+clippy planner list-plans -g <groupId>       # List plans for a Microsoft 365 group
+clippy planner list-buckets --plan <planId>  # List buckets in a plan
+clippy planner list-tasks --plan <planId>    # List tasks in a plan
+
+clippy planner create-task --plan <planId> --title "New Task" -b <bucketId>
+clippy planner update-task <taskId> --title "Updated Task" --percent 50 --assign <userId>
+```
+
+---
+
+### SharePoint Lists (`clippy sharepoint` or `clippy sp`)
+
+Manage SharePoint lists and items.
+
+```bash
+clippy sp lists --site-id <siteId>
+clippy sp items --site-id <siteId> --list-id <listId>
+clippy sp create-item --site-id <siteId> --list-id <listId> --fields '{"Title": "New Item"}'
+clippy sp update-item --site-id <siteId> --list-id <listId> --item-id <itemId> --fields '{"Title": "Updated Item"}'
+```
+
+---
+
+### SharePoint Site Pages (`clippy pages`)
+
+Manage modern SharePoint Site Pages.
+
+```bash
+clippy pages list <siteId>
+clippy pages get <siteId> <pageId>
+clippy pages update <siteId> <pageId> --title "New Title" --name "new-name.aspx"
+clippy pages publish <siteId> <pageId>
+```
 
 ---
 


### PR DESCRIPTION
Updates documentation to reflect recent additions such as Planner, SharePoint, advanced files commands, and new event/mail flags.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that expand CLI usage examples/options; no runtime or security-sensitive code changes.
> 
> **Overview**
> Updates the user-facing docs to reflect newly supported Microsoft 365 capabilities beyond mail/calendar/OneDrive, including **Microsoft Planner** task/plan commands and **SharePoint** list and site page commands.
> 
> Extends command documentation with new examples/options for `verify-token`, calendar all-day/sensitivity/category updates (including `--no-all-day`), email flag start/due dates and message sensitivity, and additional OneDrive file operations like analytics, versions/restore, and convert-download.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8768ab51e2e514347e7808104edff38052401e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->