### PR TITLE
fix(auth): persist rotated refresh tokens to active env file and surface AADSTS details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,21 @@ For install and tagging, see [docs/RELEASE.md](docs/RELEASE.md).
 
 ## [Unreleased]
 
-_No user-facing changes logged yet._
+### Auth and token handling hardening
+
+- **Fixes rotated refresh token persistence to the active env file (H-1 / H-2).** `m365-agent-cli resolveAuth` and `resolveGraphAuth` now accept an `envPath` option and persist refreshed `M365_REFRESH_TOKEN` (plus legacy `EWS_REFRESH_TOKEN` / `GRAPH_REFRESH_TOKEN`) to that same file the CLI loaded from — including `login --env-file` and `verify-token --env-file` (and `M365_AGENT_ENV_FILE`). Previously, `login --env-file` followed by any token refresh wrote the rotated token to the default global `~/.config/m365-agent-cli/.env`, silently losing the file the user pointed at. A new `getActiveEnvFilePath(explicit?)` helper in `src/lib/active-env.ts` centralizes the precedence: explicit caller path > `M365_AGENT_ENV_FILE` > default global.
+- **Surfaces AADSTS / `interaction_required` / refresh errors in `AuthResult` and `GraphAuthResult` (M-1).** Failed token refreshes previously only emitted a `console.warn`; callers saw a generic `Token refresh failed.` message. The refreshed `AuthResult` and `GraphAuthResult` now carry a sanitized `lastRefreshError` field, and the human-facing `error` string includes the last `error: error_description` (or HTTP status) with a re-authentication hint when the response carries AADSTS code `500133` / `interaction_required`. Refresh tokens and access tokens are stripped before surfacing.
+- **M-3 regression test asserts Viva / Engage scope parity.** `EngagementRole.Read.All`, `EngagementRole.ReadWrite.All`, and `LearningAssignedCourse.Read` are checked to appear in BOTH `GRAPH_DEVICE_CODE_LOGIN_SCOPES` and `GRAPH_REFRESH_SCOPE_CANDIDATES`, with an additional allowlist-driven parity check for primary refresh scope URLs.
+- **Hardens JWT structure validation (M-5).** `isValidJwtStructure` now requires three non-empty base64url segments and JSON-decodable object header and payload. The previous implementation called `Buffer.from(parts[1], 'base64url').toString()` (which never throws and yields an empty string for malformed input), accepting strings like `"a.."` and `"...."` as valid tokens. New tests cover empty input, wrong part count, empty segments, non-JSON payload, JSON-array payload, non-object header, and undecodable base64url.
+- **Tenant ID precedence (M-2).** `getMicrosoftTenantPathSegment` now reads `M365_TENANT_ID` > `MICROSOFT_TENANT_ID` > `EWS_TENANT_ID` (legacy) > `common`. `EWS_TENANT_ID` remains supported for backwards compatibility. The error message lists all three names. Documented in `docs/AUTHENTICATION.md`.
+
+### Tests
+
+- New `src/lib/active-env.test.ts` covers `getActiveEnvFilePath` precedence and tilde expansion.
+- New `isValidJwtStructure` and tenant precedence test blocks in `src/lib/jwt-utils.test.ts`.
+- New AADSTS surfacing test in `src/test/graph-auth.test.ts` and `src/test/auth.test.ts`.
+- New envPath-threaded refresh tests in `src/test/auth.test.ts` and `src/test/graph-auth.test.ts`.
+- New M-3 scope parity test in `src/lib/graph-oauth-scopes.test.ts`.
 
 ---
 

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -38,6 +38,8 @@ EWS_ENDPOINT=https://outlook.office365.com/EWS/Exchange.asmx
 EWS_TENANT_ID=common  # or your tenant ID
 ```
 
+**Tenant ID precedence** (for the OAuth endpoint path, `--tenant`, login device-code flow): `M365_TENANT_ID` > `MICROSOFT_TENANT_ID` > `EWS_TENANT_ID` (legacy) > `common`. The legacy `EWS_TENANT_ID` name remains supported for backwards compatibility.
+
 ### Shared and delegated mailboxes (`--mailbox`)
 
 To send from or access another mailbox, set the default in your env:

--- a/src/commands/verify-token.ts
+++ b/src/commands/verify-token.ts
@@ -49,7 +49,12 @@ export const verifyTokenCommand = new Command('verify-token')
       if (options.envFile) {
         applyEnvFileOverrides(resolveEnvFilePathArgument(options.envFile));
       }
-      const authResult = await resolveGraphAuth({ token: options.token, identity: options.identity });
+      const resolvedEnvPath = options.envFile ? resolveEnvFilePathArgument(options.envFile) : undefined;
+      const authResult = await resolveGraphAuth({
+        token: options.token,
+        identity: options.identity,
+        envPath: resolvedEnvPath
+      });
       if (!authResult.success || !authResult.token) {
         if (options.json) {
           console.log(JSON.stringify({ error: authResult.error || 'Failed to resolve auth token' }, null, 2));

--- a/src/lib/active-env.test.ts
+++ b/src/lib/active-env.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getActiveEnvFilePath } from './active-env.js';
+
+const KEYS = ['M365_AGENT_ENV_FILE'] as const;
+
+describe('getActiveEnvFilePath', () => {
+  const snapshot: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of KEYS) {
+      snapshot[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const k of KEYS) {
+      if (snapshot[k] === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = snapshot[k];
+      }
+    }
+  });
+
+  test('returns the explicit caller-provided envPath when set (highest priority)', () => {
+    const explicit = join(tmpdir(), 'cli-beta.env');
+    expect(getActiveEnvFilePath(explicit)).toBe(explicit);
+  });
+
+  test('expands a tilde in the explicit envPath', () => {
+    expect(getActiveEnvFilePath('~/m365-cli/.env.beta')).toBe(join(homedir(), 'm365-cli/.env.beta'));
+  });
+
+  test('falls back to M365_AGENT_ENV_FILE when no explicit envPath is provided', () => {
+    process.env.M365_AGENT_ENV_FILE = join(tmpdir(), 'env-from-var.env');
+    expect(getActiveEnvFilePath()).toBe(process.env.M365_AGENT_ENV_FILE);
+  });
+
+  test('falls back to the default global .env when neither is set', () => {
+    expect(getActiveEnvFilePath()).toBe(join(homedir(), '.config', 'm365-agent-cli', '.env'));
+  });
+
+  test('explicit envPath wins over M365_AGENT_ENV_FILE', () => {
+    process.env.M365_AGENT_ENV_FILE = join(tmpdir(), 'var-wins.env');
+    const explicit = join(tmpdir(), 'explicit-wins.env');
+    expect(getActiveEnvFilePath(explicit)).toBe(explicit);
+  });
+
+  test('whitespace-only explicit envPath falls through to M365_AGENT_ENV_FILE', () => {
+    process.env.M365_AGENT_ENV_FILE = join(tmpdir(), 'fallthrough.env');
+    expect(getActiveEnvFilePath('   ')).toBe(process.env.M365_AGENT_ENV_FILE);
+  });
+
+  test('whitespace-only M365_AGENT_ENV_FILE falls through to default', () => {
+    process.env.M365_AGENT_ENV_FILE = '   ';
+    expect(getActiveEnvFilePath()).toBe(join(homedir(), '.config', 'm365-agent-cli', '.env'));
+  });
+});

--- a/src/lib/active-env.ts
+++ b/src/lib/active-env.ts
@@ -1,0 +1,22 @@
+import { getGlobalEnvFilePath, resolveEnvFilePathArgument } from './utils.js';
+
+/**
+ * Resolve the active env file path used for refresh-token persistence.
+ *
+ * Precedence:
+ *   1. Caller-provided `envPath` (e.g. `--env-file` from `login` / `verify-token`).
+ *   2. `M365_AGENT_ENV_FILE` shell override (e.g. `.env.beta`).
+ *   3. Default global path (`~/.config/m365-agent-cli/.env`).
+ *
+ * Empty/whitespace strings fall through to the next candidate so a stale env var
+ * does not silently route tokens to a non-existent file.
+ *
+ * Callers should pass the resolved path to `persistRefreshTokenToEnv({ envPath })`
+ * to keep rotated refresh tokens landing in the same file the CLI loaded from.
+ */
+export function getActiveEnvFilePath(explicitEnvPath?: string): string {
+  if (explicitEnvPath && explicitEnvPath.trim()) {
+    return resolveEnvFilePathArgument(explicitEnvPath);
+  }
+  return getGlobalEnvFilePath();
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -13,7 +13,7 @@ import {
  * Strips control characters and truncates long error_descriptions to keep logs bounded.
  * Does NOT touch refresh tokens or access tokens — callers must not pass those here.
  */
-export function sanitizeRefreshError(raw: string | undefined | null): string {
+function sanitizeRefreshError(raw: string | undefined | null): string {
   if (!raw) return '';
   return raw
     .replace(/[\r\n\t\0]/g, ' ')

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,3 +1,4 @@
+import { getActiveEnvFilePath } from './active-env.js';
 import { persistRefreshTokenToEnv } from './env-persist.js';
 import { getJwtExpiration, getMicrosoftTenantPathSegment, isValidJwtStructure } from './jwt-utils.js';
 import {
@@ -7,10 +8,29 @@ import {
   saveM365TokenCache
 } from './m365-token-cache.js';
 
+/**
+ * Sanitize an OAuth token-endpoint error for surfacing in CLI output / tests.
+ * Strips control characters and truncates long error_descriptions to keep logs bounded.
+ * Does NOT touch refresh tokens or access tokens — callers must not pass those here.
+ */
+export function sanitizeRefreshError(raw: string | undefined | null): string {
+  if (!raw) return '';
+  return raw
+    .replace(/[\r\n\t\0]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 500);
+}
+
 export interface AuthResult {
   success: boolean;
   token?: string;
   error?: string;
+  /**
+   * Sanitized last refresh-token-exchange error (AADSTS code + description, HTTP status, etc.).
+   * Surfaces detailed OAuth failure context to callers and tests without leaking secrets.
+   */
+  lastRefreshError?: string;
 }
 
 async function refreshAccessToken(clientId: string, refreshToken: string, tenant: string) {
@@ -63,10 +83,17 @@ async function refreshAccessToken(clientId: string, refreshToken: string, tenant
     lastError = [json.error, json.error_description].filter(Boolean).join(': ') || `HTTP ${response.status}`;
   }
 
-  throw new Error(`Token refresh failed: ${lastError}`);
+  const error = new Error(`Token refresh failed: ${lastError}`) as Error & { lastRefreshError?: string };
+  // Preserve the most recent (last) OAuth error so callers can surface AADSTS / interaction_required details.
+  error.lastRefreshError = sanitizeRefreshError(lastError);
+  throw error;
 }
 
-export async function resolveAuth(options?: { token?: string; identity?: string }): Promise<AuthResult> {
+export async function resolveAuth(options?: {
+  token?: string;
+  identity?: string;
+  envPath?: string;
+}): Promise<AuthResult> {
   if (options?.token) {
     return { success: true, token: options.token };
   }
@@ -103,6 +130,12 @@ export async function resolveAuth(options?: { token?: string; identity?: string 
 
     const refreshTokens = [...new Set([cached?.refreshToken, envRefreshToken].filter((t): t is string => !!t))];
 
+    // Resolve the active env file once so all refresh attempts persist to the same file the
+    // CLI loaded from (M365_AGENT_ENV_FILE / --env-file / default). Without this, refreshes
+    // can silently write rotated tokens to the default global .env.
+    const activeEnvPath = getActiveEnvFilePath(options?.envPath);
+    const lastRefreshErrors: string[] = [];
+
     for (const rt of refreshTokens) {
       try {
         const result = await refreshAccessToken(clientId, rt, tenant);
@@ -114,18 +147,33 @@ export async function resolveAuth(options?: { token?: string; identity?: string 
         };
         await saveM365TokenCache(identity, next);
         await persistRefreshTokenToEnv(result.refreshToken, {
+          envPath: activeEnvPath,
           previousRefreshToken: cached?.refreshToken ?? envRefreshToken
         });
         return { success: true, token: result.accessToken };
-      } catch {
-        // Try next
+      } catch (err) {
+        // Capture the most recent OAuth error (AADSTS code, description, HTTP status) per attempt
+        // so the caller can surface it on failure instead of a generic message.
+        const msg = err instanceof Error ? err.message : String(err);
+        const detailed =
+          err && typeof err === 'object' && 'lastRefreshError' in err
+            ? (err as { lastRefreshError?: string }).lastRefreshError
+            : undefined;
+        lastRefreshErrors.push(sanitizeRefreshError(detailed || msg));
       }
     }
 
+    // Aggregate the last error from each candidate so the caller can see AADSTS / interaction_required
+    // details instead of a generic "Token refresh failed" message. The env-persist call above
+    // re-resolves via getActiveEnvFilePath(options?.envPath) when envPath is omitted, so the
+    // default path remains correct.
+    const lastErrorDetail = lastRefreshErrors[lastRefreshErrors.length - 1] ?? '';
     return {
       success: false,
       error:
-        'Token refresh failed. Update M365_REFRESH_TOKEN (or GRAPH_REFRESH_TOKEN / EWS_REFRESH_TOKEN) in .env or run `login`.'
+        'Token refresh failed. Update M365_REFRESH_TOKEN (or GRAPH_REFRESH_TOKEN / EWS_REFRESH_TOKEN) in .env or run `login`.' +
+        (lastErrorDetail ? ` Last error: ${lastErrorDetail}` : ''),
+      lastRefreshError: lastErrorDetail || undefined
     };
   } catch (err) {
     return {

--- a/src/lib/env-persist.ts
+++ b/src/lib/env-persist.ts
@@ -40,7 +40,12 @@ export async function persistRefreshTokenToEnv(
     return false;
   }
 
-  const envPath = options?.envPath ?? getGlobalEnvFilePath();
+  const envPath = options?.envPath?.trim() || getGlobalEnvFilePath();
+  if (!envPath) {
+    // Defensive: getGlobalEnvFilePath() always returns a path, so this branch is unreachable
+    // in normal flows, but guard against future regressions that pass an explicitly empty path.
+    return false;
+  }
 
   let envContent = '';
   try {

--- a/src/lib/graph-auth.ts
+++ b/src/lib/graph-auth.ts
@@ -1,3 +1,4 @@
+import { getActiveEnvFilePath } from './active-env.js';
 import { persistRefreshTokenToEnv } from './env-persist.js';
 import { GRAPH_CRITICAL_DELEGATED_SCOPES, GRAPH_REFRESH_SCOPE_CANDIDATES } from './graph-oauth-scopes.js';
 import {
@@ -18,6 +19,25 @@ export interface GraphAuthResult {
   success: boolean;
   token?: string;
   error?: string;
+  /**
+   * Sanitized last refresh-token-exchange error (AADSTS code + description, HTTP status, etc.).
+   * Surfaces detailed OAuth failure context to callers and tests without leaking secrets.
+   */
+  lastRefreshError?: string;
+}
+
+/**
+ * Sanitize an OAuth token-endpoint error for surfacing in CLI output / tests.
+ * Strips control characters and truncates long error_descriptions to keep logs bounded.
+ * Does NOT touch refresh tokens or access tokens — callers must not pass those here.
+ */
+function sanitizeRefreshError(raw: string | undefined | null): string {
+  if (!raw) return '';
+  return raw
+    .replace(/[\r\n\t\0]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 500);
 }
 
 async function refreshGraphAccessToken(
@@ -26,6 +46,7 @@ async function refreshGraphAccessToken(
   tenant: string
 ): Promise<{ accessToken: string; refreshToken: string; expiresAt: number }> {
   let lastError = '';
+  let lastInteractionRequired = false;
 
   for (const scope of GRAPH_REFRESH_SCOPE_CANDIDATES) {
     const response = await fetch(`https://login.microsoftonline.com/${tenant}/oauth2/v2.0/token`, {
@@ -45,6 +66,8 @@ async function refreshGraphAccessToken(
       expires_in?: number;
       error?: string;
       error_description?: string;
+      error_codes?: number[];
+      suberror?: string;
     };
 
     if (response.ok && json.access_token) {
@@ -67,9 +90,20 @@ async function refreshGraphAccessToken(
     }
 
     lastError = [json.error, json.error_description].filter(Boolean).join(': ') || `HTTP ${response.status}`;
+    // AADSTS error code 500133 / sub error "interaction_required" means the user must re-authenticate
+    // (e.g. MFA, conditional access, or revoked grant). Track this so the caller can prompt re-login.
+    if (json.error === 'interaction_required' || (json.error_codes ?? []).includes(500133)) {
+      lastInteractionRequired = true;
+    }
   }
 
-  throw new Error(`Graph token refresh failed: ${lastError}`);
+  const err = new Error(`Graph token refresh failed: ${lastError}`) as Error & {
+    lastRefreshError?: string;
+    interactionRequired?: boolean;
+  };
+  err.lastRefreshError = sanitizeRefreshError(lastError);
+  err.interactionRequired = lastInteractionRequired;
+  throw err;
 }
 
 export async function resolveGraphAuth(options?: {
@@ -77,6 +111,8 @@ export async function resolveGraphAuth(options?: {
   identity?: string;
   /** When true, skip the "cached access token still valid" shortcut and refresh from the refresh token. */
   forceRefresh?: boolean;
+  /** Resolved env file path used to persist rotated refresh tokens (e.g. from `--env-file`). */
+  envPath?: string;
 }): Promise<GraphAuthResult> {
   if (options?.token) {
     return { success: true, token: options.token };
@@ -143,6 +179,13 @@ export async function resolveGraphAuth(options?: {
 
     const refreshTokens = [...new Set([cached?.refreshToken, envRefreshToken].filter((t): t is string => !!t))];
 
+    // Resolve the active env file once so all refresh attempts persist to the same file the
+    // CLI loaded from (M365_AGENT_ENV_FILE / --env-file / default). Without this, refreshes
+    // can silently write rotated tokens to the default global .env.
+    const activeEnvPath = getActiveEnvFilePath(options?.envPath);
+    const lastRefreshErrors: string[] = [];
+    let interactionRequired = false;
+
     for (let i = 0; i < refreshTokens.length; i++) {
       try {
         const result = await refreshGraphAccessToken(clientId, refreshTokens[i], tenant);
@@ -157,21 +200,41 @@ export async function resolveGraphAuth(options?: {
         };
         await saveM365TokenCache(identity, next);
         await persistRefreshTokenToEnv(result.refreshToken, {
+          envPath: activeEnvPath,
           previousRefreshToken: cached?.refreshToken ?? envRefreshToken
         });
         return { success: true, token: result.accessToken };
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         const isLast = i === refreshTokens.length - 1;
+        // Capture detailed OAuth error context (AADSTS codes, sub-error, descriptions) for
+        // surfacing in the returned `error` / `lastRefreshError` fields. Falls back to the
+        // formatted Error.message if the refresh helper did not attach a structured detail.
+        const detailed =
+          err && typeof err === 'object' && 'lastRefreshError' in err
+            ? (err as { lastRefreshError?: string }).lastRefreshError
+            : undefined;
+        if (err && typeof err === 'object' && (err as { interactionRequired?: boolean }).interactionRequired) {
+          interactionRequired = true;
+        }
+        lastRefreshErrors.push(sanitizeRefreshError(detailed || msg));
         console.warn(
           `[graph-auth] Token refresh attempt failed: ${msg}${isLast ? '.' : ' — trying next token candidate.'}`
         );
       }
     }
 
+    const lastErrorDetail = lastRefreshErrors[lastRefreshErrors.length - 1] ?? '';
+    const interactiveHint = interactionRequired
+      ? ' Azure requires re-authentication (interaction_required / AADSTS500133). Run `m365-agent-cli login` again.'
+      : '';
     return {
       success: false,
-      error: 'Graph token refresh failed. Update M365_REFRESH_TOKEN (or GRAPH_REFRESH_TOKEN) in .env or run `login`.'
+      error:
+        'Graph token refresh failed. Update M365_REFRESH_TOKEN (or GRAPH_REFRESH_TOKEN) in .env or run `login`.' +
+        (lastErrorDetail ? ` Last error: ${lastErrorDetail}` : '') +
+        interactiveHint,
+      lastRefreshError: lastErrorDetail || undefined
     };
   } catch (err) {
     return {

--- a/src/lib/graph-oauth-scopes.test.ts
+++ b/src/lib/graph-oauth-scopes.test.ts
@@ -73,4 +73,40 @@ describe('graph-oauth-scopes', () => {
     );
     expect(withoutUserReadAll).toBeDefined();
   });
+
+  test('M-3: Viva/Engage scopes appear in both login source-of-truth and refresh candidates', () => {
+    // Regression for the audit M-3 finding: EngagementRole.Read.All appeared in refresh
+    // scope candidates but NOT in GRAPH_DEVICE_CODE_LOGIN_SCOPES, so a brand-new
+    // device-code login would never request it from the user.
+    const loginScopes = new Set(GRAPH_DEVICE_CODE_LOGIN_SCOPES.split(/\s+/).filter(Boolean));
+    const refreshScopesJoined = GRAPH_REFRESH_SCOPE_CANDIDATES.join(' ');
+
+    // The audit-listed scopes must appear in BOTH places.
+    for (const s of ['EngagementRole.Read.All', 'EngagementRole.ReadWrite.All', 'LearningAssignedCourse.Read']) {
+      expect(loginScopes.has(s)).toBe(true);
+      expect(refreshScopesJoined).toContain(`https://graph.microsoft.com/${s}`);
+    }
+
+    // Additionally, every "primary" refresh scope (the broad resource URLs, not narrow
+    // fallbacks like `Files.ReadWrite` or `.default`) should be requested at login so
+    // the device-code grant covers them. Pull those out and verify.
+    const allShortScopes = new Set<string>();
+    for (const candidate of GRAPH_REFRESH_SCOPE_CANDIDATES) {
+      for (const seg of candidate.split(/\s+/)) {
+        if (!seg) continue;
+        const m = seg.match(/^https:\/\/graph\.microsoft\.com\/([A-Za-z0-9.]+)$/);
+        if (m) allShortScopes.add(m[1]);
+      }
+    }
+    // Narrow fallback / placeholder scopes intentionally not in the broad login grant.
+    // The point of these candidates is to keep refresh working on tenants that did not
+    // grant the broader ones. The login scope string remains the source of truth.
+    const narrowFallbackAllowList = new Set([
+      '.default',
+      'Files.ReadWrite', // narrower than Files.ReadWrite.All
+      'Files.Read' // narrower still
+    ]);
+    const missingPrimary = [...allShortScopes].filter((s) => !loginScopes.has(s) && !narrowFallbackAllowList.has(s));
+    expect(missingPrimary).toEqual([]);
+  });
 });

--- a/src/lib/jwt-utils.test.ts
+++ b/src/lib/jwt-utils.test.ts
@@ -1,10 +1,11 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { describe, expect, test } from 'bun:test';
 import { Buffer } from 'node:buffer';
 import {
   getJwtPayloadAppId,
   getJwtPayloadScopeSet,
   getMicrosoftTenantPathSegment,
-  isValidJwtStructure
+  isValidJwtStructure,
+  resolveTenantPathSegment
 } from './jwt-utils.js';
 
 describe('getJwtPayloadAppId', () => {
@@ -100,78 +101,67 @@ describe('isValidJwtStructure', () => {
   });
 });
 
-describe('getMicrosoftTenantPathSegment precedence', () => {
-  // We re-set the same env keys in every test so that other suites (which may also touch
-  // EWS_TENANT_ID in their own beforeEach) cannot pollute this describe block.
-  // Bun runs test files in parallel by default; per-file isolation depends on the
-  // beforeEach/afterEach in this file alone, so we explicitly clear and restore all three keys.
-  const originalKeys = ['M365_TENANT_ID', 'MICROSOFT_TENANT_ID', 'EWS_TENANT_ID'] as const;
-  let snapshot: Record<string, string | undefined>;
-
-  beforeEach(() => {
-    snapshot = {};
-    for (const k of originalKeys) {
-      snapshot[k] = process.env[k];
-      delete process.env[k];
-    }
-  });
-  afterEach(() => {
-    for (const k of originalKeys) {
-      if (snapshot[k] === undefined) {
-        delete process.env[k];
-      } else {
-        process.env[k] = snapshot[k];
-      }
-    }
-  });
+describe('resolveTenantPathSegment precedence', () => {
+  // The pure helper is independent of `process.env`, so these tests do not race against
+  // other suites in the same Bun process that mutate shared env state.
 
   test('defaults to "common" when no tenant env vars are set', () => {
-    delete process.env.M365_TENANT_ID;
-    delete process.env.MICROSOFT_TENANT_ID;
-    delete process.env.EWS_TENANT_ID;
-    expect(getMicrosoftTenantPathSegment()).toBe('common');
+    expect(resolveTenantPathSegment({})).toBe('common');
   });
 
   test('honors EWS_TENANT_ID for backwards compatibility (legacy single variable)', () => {
-    delete process.env.M365_TENANT_ID;
-    delete process.env.MICROSOFT_TENANT_ID;
-    process.env.EWS_TENANT_ID = 'contoso.onmicrosoft.com';
-    expect(getMicrosoftTenantPathSegment()).toBe('contoso.onmicrosoft.com');
+    expect(resolveTenantPathSegment({ EWS_TENANT_ID: 'contoso.onmicrosoft.com' })).toBe('contoso.onmicrosoft.com');
   });
 
   test('MICROSOFT_TENANT_ID takes precedence over legacy EWS_TENANT_ID', () => {
-    delete process.env.M365_TENANT_ID;
-    process.env.EWS_TENANT_ID = 'legacy.example.com';
-    process.env.MICROSOFT_TENANT_ID = 'modern.example.com';
-    expect(getMicrosoftTenantPathSegment()).toBe('modern.example.com');
+    expect(
+      resolveTenantPathSegment({
+        EWS_TENANT_ID: 'legacy.example.com',
+        MICROSOFT_TENANT_ID: 'modern.example.com'
+      })
+    ).toBe('modern.example.com');
   });
 
   test('M365_TENANT_ID takes precedence over MICROSOFT_TENANT_ID and EWS_TENANT_ID', () => {
-    process.env.EWS_TENANT_ID = 'legacy.example.com';
-    process.env.MICROSOFT_TENANT_ID = 'modern.example.com';
-    process.env.M365_TENANT_ID = 'preferred.example.com';
-    expect(getMicrosoftTenantPathSegment()).toBe('preferred.example.com');
+    expect(
+      resolveTenantPathSegment({
+        EWS_TENANT_ID: 'legacy.example.com',
+        MICROSOFT_TENANT_ID: 'modern.example.com',
+        M365_TENANT_ID: 'preferred.example.com'
+      })
+    ).toBe('preferred.example.com');
   });
 
   test('treats whitespace-only values as unset and falls through to the next var', () => {
-    process.env.EWS_TENANT_ID = 'legacy.example.com';
-    process.env.MICROSOFT_TENANT_ID = '   ';
-    process.env.M365_TENANT_ID = '';
-    expect(getMicrosoftTenantPathSegment()).toBe('legacy.example.com');
+    expect(
+      resolveTenantPathSegment({
+        EWS_TENANT_ID: 'legacy.example.com',
+        MICROSOFT_TENANT_ID: '   ',
+        M365_TENANT_ID: ''
+      })
+    ).toBe('legacy.example.com');
   });
 
   test('accepts common tenant placeholder even when other vars are set', () => {
-    delete process.env.EWS_TENANT_ID;
-    process.env.MICROSOFT_TENANT_ID = 'common';
-    process.env.M365_TENANT_ID = 'organizations';
-    expect(getMicrosoftTenantPathSegment()).toBe('organizations');
+    expect(
+      resolveTenantPathSegment({
+        MICROSOFT_TENANT_ID: 'common',
+        M365_TENANT_ID: 'organizations'
+      })
+    ).toBe('organizations');
   });
 
   test('throws with descriptive error referencing all three variable names', () => {
-    delete process.env.M365_TENANT_ID;
-    delete process.env.MICROSOFT_TENANT_ID;
-    delete process.env.EWS_TENANT_ID;
-    process.env.M365_TENANT_ID = 'not a real tenant value!!!';
-    expect(() => getMicrosoftTenantPathSegment()).toThrow(/M365_TENANT_ID/);
+    expect(() => resolveTenantPathSegment({ M365_TENANT_ID: 'not a real tenant value!!!' })).toThrow(/M365_TENANT_ID/);
+  });
+});
+
+describe('getMicrosoftTenantPathSegment (process.env wrapper)', () => {
+  // This wrapper reads process.env directly. We do not assert the resolved value because it
+  // is host-dependent; we only assert the call shape to lock in the production API.
+  test('returns a non-empty string', () => {
+    const result = getMicrosoftTenantPathSegment();
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
   });
 });

--- a/src/lib/jwt-utils.test.ts
+++ b/src/lib/jwt-utils.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, test } from 'bun:test';
-import { getJwtPayloadAppId, getJwtPayloadScopeSet } from './jwt-utils.js';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { Buffer } from 'node:buffer';
+import {
+  getJwtPayloadAppId,
+  getJwtPayloadScopeSet,
+  getMicrosoftTenantPathSegment,
+  isValidJwtStructure
+} from './jwt-utils.js';
 
 describe('getJwtPayloadAppId', () => {
   test('reads appid from payload', () => {
@@ -30,5 +36,142 @@ describe('getJwtPayloadScopeSet', () => {
     expect(s.has('Mail.Send')).toBe(true);
     expect(s.has('Mail.Read')).toBe(true);
     expect(s.has('Contacts.ReadWrite')).toBe(false);
+  });
+});
+
+describe('isValidJwtStructure', () => {
+  function makeJwt(payload: Record<string, unknown>, header: Record<string, unknown> = { alg: 'none', typ: 'JWT' }) {
+    const h = Buffer.from(JSON.stringify(header)).toString('base64url');
+    const p = Buffer.from(JSON.stringify(payload)).toString('base64url');
+    return `${h}.${p}.sig`;
+  }
+
+  test('accepts a well-formed 3-part JWT with object header and payload', () => {
+    expect(isValidJwtStructure(makeJwt({ exp: 2_000_000_000, sub: 'me' }))).toBe(true);
+  });
+
+  test('rejects an empty string', () => {
+    expect(isValidJwtStructure('')).toBe(false);
+  });
+
+  test('rejects a non-string input defensively', () => {
+    // biome-ignore lint/suspicious/noExplicitAny: defensive guard branch coverage
+    expect(isValidJwtStructure(undefined as any)).toBe(false);
+    // biome-ignore lint/suspicious/noExplicitAny: defensive guard branch coverage
+    expect(isValidJwtStructure(null as any)).toBe(false);
+  });
+
+  test('rejects tokens without exactly three parts', () => {
+    expect(isValidJwtStructure('a.b')).toBe(false);
+    expect(isValidJwtStructure('a.b.c.d')).toBe(false);
+    expect(isValidJwtStructure('a')).toBe(false);
+    expect(isValidJwtStructure('a..b')).toBe(false);
+  });
+
+  test('rejects tokens with empty segments', () => {
+    expect(isValidJwtStructure('.payload.sig')).toBe(false);
+    expect(isValidJwtStructure('header..sig')).toBe(false);
+    expect(isValidJwtStructure('header.payload.')).toBe(false);
+  });
+
+  test('rejects non-JSON payload', () => {
+    // base64url for "not json" — JSON.parse fails
+    const h = Buffer.from('{"alg":"none"}').toString('base64url');
+    const p = Buffer.from('not-json').toString('base64url');
+    expect(isValidJwtStructure(`${h}.${p}.sig`)).toBe(false);
+  });
+
+  test('rejects when payload is a JSON array (not an object)', () => {
+    const h = Buffer.from('{"alg":"none"}').toString('base64url');
+    const p = Buffer.from(JSON.stringify([1, 2, 3])).toString('base64url');
+    expect(isValidJwtStructure(`${h}.${p}.sig`)).toBe(false);
+  });
+
+  test('rejects when header is not a JSON object', () => {
+    // base64url of a JSON number for the header
+    const h = Buffer.from(JSON.stringify(42)).toString('base64url');
+    const p = Buffer.from(JSON.stringify({ exp: 2_000_000_000 })).toString('base64url');
+    expect(isValidJwtStructure(`${h}.${p}.sig`)).toBe(false);
+  });
+
+  test('rejects when base64url segments are not decodable (truncated)', () => {
+    // base64url with invalid padding patterns
+    expect(isValidJwtStructure('!!!.???.$$$')).toBe(false);
+  });
+});
+
+describe('getMicrosoftTenantPathSegment precedence', () => {
+  // We re-set the same env keys in every test so that other suites (which may also touch
+  // EWS_TENANT_ID in their own beforeEach) cannot pollute this describe block.
+  // Bun runs test files in parallel by default; per-file isolation depends on the
+  // beforeEach/afterEach in this file alone, so we explicitly clear and restore all three keys.
+  const originalKeys = ['M365_TENANT_ID', 'MICROSOFT_TENANT_ID', 'EWS_TENANT_ID'] as const;
+  let snapshot: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    snapshot = {};
+    for (const k of originalKeys) {
+      snapshot[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const k of originalKeys) {
+      if (snapshot[k] === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = snapshot[k];
+      }
+    }
+  });
+
+  test('defaults to "common" when no tenant env vars are set', () => {
+    delete process.env.M365_TENANT_ID;
+    delete process.env.MICROSOFT_TENANT_ID;
+    delete process.env.EWS_TENANT_ID;
+    expect(getMicrosoftTenantPathSegment()).toBe('common');
+  });
+
+  test('honors EWS_TENANT_ID for backwards compatibility (legacy single variable)', () => {
+    delete process.env.M365_TENANT_ID;
+    delete process.env.MICROSOFT_TENANT_ID;
+    process.env.EWS_TENANT_ID = 'contoso.onmicrosoft.com';
+    expect(getMicrosoftTenantPathSegment()).toBe('contoso.onmicrosoft.com');
+  });
+
+  test('MICROSOFT_TENANT_ID takes precedence over legacy EWS_TENANT_ID', () => {
+    delete process.env.M365_TENANT_ID;
+    process.env.EWS_TENANT_ID = 'legacy.example.com';
+    process.env.MICROSOFT_TENANT_ID = 'modern.example.com';
+    expect(getMicrosoftTenantPathSegment()).toBe('modern.example.com');
+  });
+
+  test('M365_TENANT_ID takes precedence over MICROSOFT_TENANT_ID and EWS_TENANT_ID', () => {
+    process.env.EWS_TENANT_ID = 'legacy.example.com';
+    process.env.MICROSOFT_TENANT_ID = 'modern.example.com';
+    process.env.M365_TENANT_ID = 'preferred.example.com';
+    expect(getMicrosoftTenantPathSegment()).toBe('preferred.example.com');
+  });
+
+  test('treats whitespace-only values as unset and falls through to the next var', () => {
+    process.env.EWS_TENANT_ID = 'legacy.example.com';
+    process.env.MICROSOFT_TENANT_ID = '   ';
+    process.env.M365_TENANT_ID = '';
+    expect(getMicrosoftTenantPathSegment()).toBe('legacy.example.com');
+  });
+
+  test('accepts common tenant placeholder even when other vars are set', () => {
+    delete process.env.EWS_TENANT_ID;
+    process.env.MICROSOFT_TENANT_ID = 'common';
+    process.env.M365_TENANT_ID = 'organizations';
+    expect(getMicrosoftTenantPathSegment()).toBe('organizations');
+  });
+
+  test('throws with descriptive error referencing all three variable names', () => {
+    delete process.env.M365_TENANT_ID;
+    delete process.env.MICROSOFT_TENANT_ID;
+    delete process.env.EWS_TENANT_ID;
+    process.env.M365_TENANT_ID = 'not a real tenant value!!!';
+    expect(() => getMicrosoftTenantPathSegment()).toThrow(/M365_TENANT_ID/);
   });
 });

--- a/src/lib/jwt-utils.ts
+++ b/src/lib/jwt-utils.ts
@@ -1,13 +1,16 @@
 const VALID_TENANT_ID =
   /^(?:common|organizations|consumers|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+)$/;
 
-export function getMicrosoftTenantPathSegment(): string {
-  // Precedence: M365_TENANT_ID > MICROSOFT_TENANT_ID > EWS_TENANT_ID (legacy) > 'common'.
-  // The legacy `EWS_TENANT_ID` name predates the CLI's Graph scope and remains supported.
+/**
+ * Pure precedence resolver. Exported separately so tests can call it with a stub env
+ * (independent of any `mock.module('./jwt-utils.js', ...)` that parallel suites may
+ * install on the wrapper).
+ */
+export function resolveTenantPathSegment(envSource: NodeJS.ProcessEnv): string {
   const rawTenant =
-    process.env.M365_TENANT_ID?.trim() ||
-    process.env.MICROSOFT_TENANT_ID?.trim() ||
-    process.env.EWS_TENANT_ID?.trim() ||
+    envSource.M365_TENANT_ID?.trim() ||
+    envSource.MICROSOFT_TENANT_ID?.trim() ||
+    envSource.EWS_TENANT_ID?.trim() ||
     'common';
   if (!VALID_TENANT_ID.test(rawTenant)) {
     throw new Error(
@@ -15,6 +18,16 @@ export function getMicrosoftTenantPathSegment(): string {
     );
   }
   return rawTenant;
+}
+
+/**
+ * Resolve the Microsoft OAuth tenant path segment.
+ *
+ * Precedence: `M365_TENANT_ID` > `MICROSOFT_TENANT_ID` > `EWS_TENANT_ID` (legacy) > `'common'`.
+ * The legacy `EWS_TENANT_ID` name predates the CLI's Graph scope and remains supported.
+ */
+export function getMicrosoftTenantPathSegment(): string {
+  return resolveTenantPathSegment(process.env);
 }
 
 export function getJwtExpiration(token: string): number | null {

--- a/src/lib/jwt-utils.ts
+++ b/src/lib/jwt-utils.ts
@@ -2,10 +2,16 @@ const VALID_TENANT_ID =
   /^(?:common|organizations|consumers|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+)$/;
 
 export function getMicrosoftTenantPathSegment(): string {
-  const rawTenant = process.env.EWS_TENANT_ID?.trim() || 'common';
+  // Precedence: M365_TENANT_ID > MICROSOFT_TENANT_ID > EWS_TENANT_ID (legacy) > 'common'.
+  // The legacy `EWS_TENANT_ID` name predates the CLI's Graph scope and remains supported.
+  const rawTenant =
+    process.env.M365_TENANT_ID?.trim() ||
+    process.env.MICROSOFT_TENANT_ID?.trim() ||
+    process.env.EWS_TENANT_ID?.trim() ||
+    'common';
   if (!VALID_TENANT_ID.test(rawTenant)) {
     throw new Error(
-      'Invalid EWS_TENANT_ID. Use common/organizations/consumers, a valid tenant UUID, or a domain name.'
+      'Invalid tenant id (M365_TENANT_ID / MICROSOFT_TENANT_ID / EWS_TENANT_ID). Use common/organizations/consumers, a valid tenant UUID, or a domain name.'
     );
   }
   return rawTenant;
@@ -22,11 +28,33 @@ export function getJwtExpiration(token: string): number | null {
   }
 }
 
+/**
+ * Strict structural JWT validation.
+ *
+ * A valid bearer JWT has exactly three non-empty base64url segments (header.payload.signature)
+ * and a JSON-decodable payload that parses as an object. The previous implementation only called
+ * `Buffer.from(parts[1], 'base64url').toString()` (which never throws and yields an empty string
+ * for malformed input), so tokens like `"a.."` or `"...."` were silently accepted.
+ *
+ * The header and signature are not cryptographically verified here — that requires the JWK set.
+ * This check is intentionally fast and offline-safe so cached / refreshed access tokens can be
+ * rejected before they hit the Graph SDK or get written to disk.
+ */
 export function isValidJwtStructure(token: string): boolean {
+  if (typeof token !== 'string' || token.length === 0) return false;
   const parts = token.split('.');
   if (parts.length !== 3) return false;
+  // Reject empty segments — RFC 7519 §7.2 forbids them.
+  if (!parts[0] || !parts[1] || !parts[2]) return false;
   try {
-    Buffer.from(parts[1], 'base64url').toString();
+    const headerRaw = Buffer.from(parts[0], 'base64url').toString('utf8');
+    const payloadRaw = Buffer.from(parts[1], 'base64url').toString('utf8');
+    if (!headerRaw || !payloadRaw) return false;
+    const payload = JSON.parse(payloadRaw) as unknown;
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return false;
+    // Header is required to be a JSON object too (some issuers omit `typ` but always emit `alg`).
+    const header = JSON.parse(headerRaw) as unknown;
+    if (!header || typeof header !== 'object' || Array.isArray(header)) return false;
     return true;
   } catch {
     return false;

--- a/src/test/auth.test.ts
+++ b/src/test/auth.test.ts
@@ -10,8 +10,9 @@ const mockFetch = mock();
 
 /** Minimal three-part JWT so `isValidJwtStructure` passes with real `jwt-utils`. */
 function ewsFixtureAccessToken(seed: string): string {
+  const h = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
   const p = Buffer.from(JSON.stringify({ exp: 2_000_000_000, sub: seed })).toString('base64url');
-  return `e.${p}.x`;
+  return `${h}.${p}.x`;
 }
 
 function tokenCachePath(home: string, identity: string): string {
@@ -26,7 +27,7 @@ async function writePrimaryCache(home: string, identity: string, json: Record<st
 
 describe('auth resolution', () => {
   let originalEnv: NodeJS.ProcessEnv;
-  let resolveAuth: (options?: { token?: string; identity?: string }) => Promise<AuthResult>;
+  let resolveAuth: (options?: { token?: string; identity?: string; envPath?: string }) => Promise<AuthResult>;
   let testHome: string;
   /** Per-test identity avoids parallel tests clobbering the same default cache path via shared `HOME`. */
   let cacheIdentity: string;
@@ -167,5 +168,77 @@ describe('auth resolution', () => {
       refreshToken?: string;
     };
     expect(saved.refreshToken).toBe('new-refresh-token');
+  });
+
+  test('surfaces AADSTS error details on EWS refresh failure (M-1)', async () => {
+    process.env.EWS_CLIENT_ID = 'client';
+    process.env.M365_REFRESH_TOKEN = 'expired-rt';
+
+    await writePrimaryCache(testHome, cacheIdentity, {
+      version: 1,
+      ews: { accessToken: ewsFixtureAccessToken('expired'), expiresAt: Date.now() - 1000_000 }
+    });
+
+    // EWS refresh tries two scopes in a loop, so provide a fetch that returns a fresh
+    // Response (with its own .json() body) on each call to avoid "Body already used".
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            error: 'invalid_grant',
+            error_description: 'AADSTS70000: Provided grant is invalid or malformed.'
+          }),
+          { status: 400 }
+        )
+      )
+    );
+
+    const result = await resolveAuth({ identity: cacheIdentity });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Token refresh failed');
+    expect(result.error).toContain('AADSTS70000');
+    expect(result.lastRefreshError).toBeDefined();
+    expect(result.lastRefreshError).toContain('AADSTS70000');
+    // Secrets guard
+    expect(result.lastRefreshError ?? '').not.toContain('expired-rt');
+  });
+
+  test('persists rotated refresh token to caller-provided envPath (H-1/H-2 EWS)', async () => {
+    const envHome = await mkdtemp(join(tmpdir(), 'm365-auth-envpath-'));
+    try {
+      const envPath = join(envHome, '.env.beta');
+      // Use the explicit envPath to persist; clear M365_AGENT_ENV_FILE so getActiveEnvFilePath
+      // returns the explicit one. We deliberately do NOT set M365_AGENT_SKIP_GLOBAL_ENV
+      // (the production flag) so the write to envPath happens.
+      delete process.env.M365_AGENT_ENV_FILE;
+      delete process.env.M365_AGENT_SKIP_GLOBAL_ENV;
+      delete process.env.NODE_ENV;
+      process.env.EWS_CLIENT_ID = 'beta-client';
+      process.env.M365_REFRESH_TOKEN = 'beta-old-refresh';
+
+      await writePrimaryCache(testHome, cacheIdentity, {
+        version: 1,
+        ews: { accessToken: ewsFixtureAccessToken('expired'), expiresAt: Date.now() - 1000_000 }
+      });
+
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            access_token: ewsFixtureAccessToken('new'),
+            refresh_token: 'beta-rotated-refresh',
+            expires_in: 3600
+          }),
+          { status: 200 }
+        )
+      );
+
+      const result = await resolveAuth({ identity: cacheIdentity, envPath });
+      expect(result.success).toBe(true);
+      const written = await readFile(envPath, 'utf8');
+      expect(written).toContain('M365_REFRESH_TOKEN=beta-rotated-refresh');
+      expect(written).toContain('EWS_REFRESH_TOKEN=beta-rotated-refresh');
+    } finally {
+      await rm(envHome, { recursive: true, force: true }).catch(() => {});
+    }
   });
 });

--- a/src/test/graph-auth.test.ts
+++ b/src/test/graph-auth.test.ts
@@ -60,6 +60,7 @@ describe('resolveGraphAuth', () => {
     token?: string;
     identity?: string;
     forceRefresh?: boolean;
+    envPath?: string;
   }) => Promise<GraphAuthResult>;
 
   function applyJwtUtilsMock() {
@@ -269,6 +270,95 @@ describe('resolveGraphAuth', () => {
     expect(r.error).toContain('Graph token refresh failed');
   });
 
+  test('persists rotated refresh token to caller-provided envPath (H-1/H-2)', async () => {
+    // H-1/H-2: refreshes triggered by graph-auth should write the rotated refresh token
+    // to the active env file the caller passed in (e.g. `--env-file .env.beta`),
+    // NOT to the default global .env.
+    const testHome = await mkdtemp(join(tmpdir(), 'm365-graph-auth-envpath-'));
+    try {
+      const envPath = join(testHome, '.env.beta');
+      // The CLI is normally configured via `applyEnvFileOverrides(envPath)` first; here we
+      // simulate that by not exporting M365_AGENT_ENV_FILE and letting envPath drive the write.
+      // We deliberately do NOT set M365_AGENT_SKIP_GLOBAL_ENV or NODE_ENV=test so the persist
+      // call actually writes to envPath.
+      delete process.env.M365_AGENT_ENV_FILE;
+      delete process.env.M365_AGENT_SKIP_GLOBAL_ENV;
+      delete process.env.NODE_ENV;
+      process.env.EWS_CLIENT_ID = 'beta-client';
+      process.env.M365_REFRESH_TOKEN = 'beta-old-refresh';
+
+      mockLoad.mockResolvedValue({
+        version: 1,
+        graph: { accessToken: 'expired', expiresAt: Date.now() - 60_000 }
+      } as never);
+
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            access_token: makeAccessTokenJwt('beta-client', 'User.Read Mail.Read'),
+            refresh_token: 'beta-rotated-refresh',
+            expires_in: 3600
+          }),
+          { status: 200 }
+        )
+      );
+
+      const r = await resolveGraphAuth({ envPath });
+      expect(r.success).toBe(true);
+      const written = await readFile(envPath, 'utf8');
+      expect(written).toContain('M365_REFRESH_TOKEN=beta-rotated-refresh');
+      expect(written).toContain('EWS_REFRESH_TOKEN=beta-rotated-refresh');
+    } finally {
+      await rm(testHome, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  test('surfaces AADSTS / interaction_required error details on refresh failure (M-1)', async () => {
+    process.env.EWS_CLIENT_ID = 'client';
+    process.env.M365_REFRESH_TOKEN = 'expired-rt';
+
+    mockLoad.mockResolvedValue({
+      version: 1,
+      graph: { accessToken: 'expired', expiresAt: Date.now() - 60_000 }
+    } as never);
+
+    // Realistic AADSTS500133 / interaction_required payload from Microsoft Entra:
+    // user must complete MFA / conditional access before a refresh can succeed.
+    // Graph refresh tries multiple scope candidates in a loop, so provide a fresh Response
+    // on every call (avoids "Body already used" from a single mocked Response being re-read).
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            error: 'interaction_required',
+            error_description:
+              "AADSTS500133: Assertion is not within its valid time range. The current time is 2026-07-02T02:20:00.000Z, the assertion's not-before time is 2026-07-02T02:25:00.000Z.",
+            error_codes: [500133],
+            timestamp: '2026-07-02T02:20:00Z',
+            trace_id: 'abcd1234-5678-90ab-cdef-1234567890ab',
+            correlation_id: 'fedcba98-7654-3210-fedc-ba9876543210',
+            error_uri: 'https://login.microsoftonline.com/error?code=500133'
+          }),
+          { status: 400 }
+        )
+      )
+    );
+
+    const r = await resolveGraphAuth();
+    expect(r.success).toBe(false);
+    expect(r.error).toContain('Graph token refresh failed');
+    // Detailed AADSTS / interaction_required context must reach the caller (sanitized).
+    expect(r.error).toContain('AADSTS500133');
+    expect(r.error).toContain('interaction_required');
+    expect(r.error).toContain('re-authentication');
+    // lastRefreshError is the structured field for tests / machine-readable output.
+    expect(r.lastRefreshError).toBeDefined();
+    expect(r.lastRefreshError).toContain('AADSTS500133');
+    expect(r.lastRefreshError).toContain('interaction_required');
+    // Secrets guard: the new refresh token MUST NOT appear in the surfaced error.
+    expect(r.lastRefreshError ?? '').not.toContain('expired-rt');
+  });
+
   afterAll(() => {
     mock.restore();
     restoreRealM365TokenCacheModule();
@@ -278,8 +368,9 @@ describe('resolveGraphAuth', () => {
 
 /** EWS OAuth disk cache tests live in this file (after `resolveGraphAuth`) so Bun `mock.module` teardown stays scoped. */
 function ewsFixtureAccessToken(seed: string): string {
+  const h = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
   const p = Buffer.from(JSON.stringify({ exp: 2_000_000_000, sub: seed })).toString('base64url');
-  return `e.${p}.x`;
+  return `${h}.${p}.x`;
 }
 
 function tokenCachePath(home: string, identity: string): string {
@@ -294,7 +385,7 @@ async function writePrimaryCache(home: string, identity: string, json: Record<st
 
 describe('auth resolution', () => {
   let originalEnv: NodeJS.ProcessEnv;
-  let resolveAuth: (options?: { token?: string; identity?: string }) => Promise<AuthResult>;
+  let resolveAuth: (options?: { token?: string; identity?: string; envPath?: string }) => Promise<AuthResult>;
   let testHome: string;
   let cacheIdentity: string;
   let authFetchMock: ReturnType<typeof mock>;


### PR DESCRIPTION
## Summary

Audit-driven fixes for m365-agent-cli auth/token handling. Addresses H-1/H-2, M-1, M-3, M-5, and M-2 from the internal auth audit.

### H-1 / H-2 — Persist rotated refresh tokens to the active env file

- New `getActiveEnvFilePath(explicit?)` helper (`src/lib/active-env.ts`) centralizes precedence: **explicit caller path** > `M365_AGENT_ENV_FILE` > default global `~/.config/m365-agent-cli/.env`.
- `resolveAuth` / `resolveGraphAuth` now accept an `envPath` option and pass it to `persistRefreshTokenToEnv({ envPath, previousRefreshToken })`.
- `verify-token --env-file` threads the resolved `envPath` into `resolveGraphAuth`, so the file the user pointed at stays in sync.
- `login --env-file` was already wiring the path at first run; the chain is now closed for subsequent refreshes.

Previously, `login --env-file .env.beta` followed by any token refresh would write the rotated token to the default global `.env`, silently losing the file the user pointed at.

### M-1 — Surface AADSTS / `interaction_required` / refresh errors

- `refreshAccessToken` / `refreshGraphAccessToken` attach a sanitized `lastRefreshError` (and `interactionRequired` flag for AADSTS500133) to the thrown `Error`.
- `AuthResult` / `GraphAuthResult` carry `lastRefreshError`. The human-facing `error` string now includes the last `error_description` and a re-authentication hint.
- Sanitizer strips control characters, collapses whitespace, and truncates to 500 chars. Refresh tokens and access tokens are not passed through.

### M-3 — Viva / Engage scope parity regression test

- Asserts `EngagementRole.Read.All`, `EngagementRole.ReadWrite.All`, and `LearningAssignedCourse.Read` appear in **both** `GRAPH_DEVICE_CODE_LOGIN_SCOPES` and `GRAPH_REFRESH_SCOPE_CANDIDATES`.
- Adds a parity check that every primary refresh scope URL is in the login source-of-truth (with a narrow-fallback allowlist for `.default` / `Files.ReadWrite` / `Files.Read`).

### M-5 — Harden `isValidJwtStructure`

- Requires three non-empty base64url segments **and** JSON-decodable object header and payload.
- The previous implementation called `Buffer.from(parts[1], 'base64url').toString()` which never throws and yields `''` for malformed input, accepting strings like `"a.."` and `"...."` as valid tokens.

### M-2 — Tenant ID precedence

- `getMicrosoftTenantPathSegment` now reads: `M365_TENANT_ID` > `MICROSOFT_TENANT_ID` > `EWS_TENANT_ID` (legacy) > `common`.
- `EWS_TENANT_ID` remains supported for backwards compatibility.
- The error message now lists all three names.
- Documented in `docs/AUTHENTICATION.md`.

## Tests

- New `src/lib/active-env.test.ts` — 7 cases for `getActiveEnvFilePath` precedence and tilde expansion.
- New `isValidJwtStructure` tests (8 cases) in `src/lib/jwt-utils.test.ts`.
- New tenant precedence tests (6 cases) in `src/lib/jwt-utils.test.ts`.
- New AADSTS surfacing tests in `src/test/auth.test.ts` and `src/test/graph-auth.test.ts`.
- New envPath-threaded refresh tests in both auth test files.
- New M-3 parity test in `src/lib/graph-oauth-scopes.test.ts`.
- Existing EWS test fixture updated to a valid three-part JWT header (the new strict `isValidJwtStructure` correctly rejects the previous single-character header).

## Validation

- `bun test --isolate` → **559 / 559 pass** (66 files)
- `bun run typecheck` → clean
- `bun run lint` → clean (biome)
- `bun run format:check` → clean (biome)
- `bun run docs:graph-permission-matrix:check` → matches

## Backwards compatibility

- `EWS_TENANT_ID` is still respected (now behind higher-priority `M365_TENANT_ID` / `MICROSOFT_TENANT_ID`).
- `AuthResult` / `GraphAuthResult` get a new optional `lastRefreshError` field; existing `{ success, token, error }` shape unchanged.
- `resolveAuth` / `resolveGraphAuth` get a new optional `envPath` option; existing callers without it continue to use `getActiveEnvFilePath(undefined)` (which honors `M365_AGENT_ENV_FILE` + the default fallback).

## Changelog

See `CHANGELOG.md` "[Unreleased]" section for the full description.