### PR TITLE
fix(auth): surface interaction_required on EWS refresh, harden error sanitizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "m365-agent-cli",
-  "version": "2026.6.30",
+  "version": "2026.7.3",
   "description": "Microsoft 365 from your terminal: calendar, mail, OneDrive, Planner, Teams, Graph \u2014 one OAuth login",
   "repository": {
     "type": "git",

--- a/skills/m365-agent-cli/SKILL.md
+++ b/skills/m365-agent-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: m365-agent-cli
-version: 2026.6.30
+version: 2026.7.3
 description: Microsoft 365 CLI (EWS + Graph) for calendar, mail, OneDrive, Planner, SharePoint, To Do, Teams, Bookings, Excel-on-drive, presence, inbox rules, delegates, subscriptions, Graph Search, Microsoft Viva / employee experience (`viva` — Graph beta: tenant `/employeeExperience`, user work time/insights/roles/learning, admin+org itemInsights, workHoursAndLocations, meeting Engage Q&A), Microsoft 365 Copilot APIs (`copilot` — retrieval, search, chat, reports, packages, meeting insights, interaction export, notify-help), and raw `graph invoke`/`graph batch`. Use when the user needs Outlook/Exchange, Graph, or M365 automation from the terminal.
 # `version` matches the npm CLI release; run `npm run sync-skill` after bumping package.json.
 metadata:

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { createInterface } from 'node:readline/promises';
@@ -6,7 +6,7 @@ import { Command } from 'commander';
 import { atomicWriteUtf8File } from '../lib/atomic-write.js';
 import { persistRefreshTokenToEnv } from '../lib/env-persist.js';
 import { GRAPH_DEVICE_CODE_LOGIN_SCOPES } from '../lib/graph-oauth-scopes.js';
-import { getMicrosoftTenantPathSegment } from '../lib/jwt-utils.js';
+import { getMicrosoftTenantPathSegment, isValidJwtStructure } from '../lib/jwt-utils.js';
 import { applyEnvFileOverrides, getGlobalEnvFilePath, resolveEnvFilePathArgument } from '../lib/utils.js';
 
 async function performDeviceCodeFlow(
@@ -74,9 +74,8 @@ async function performDeviceCodeFlow(
       // Extract username from access token
 
       try {
-        const parts = tokenJson.access_token.split('.');
-
-        if (parts.length === 3) {
+        if (isValidJwtStructure(tokenJson.access_token)) {
+          const parts = tokenJson.access_token.split('.');
           const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
 
           const rawUsername = payload.upn || payload.email;
@@ -86,6 +85,7 @@ async function performDeviceCodeFlow(
             let envContent = '';
 
             mkdirSync(dirname(envPath), { recursive: true, mode: 0o700 });
+            chmodSync(dirname(envPath), 0o700);
 
             try {
               envContent = await readFile(envPath, 'utf8');
@@ -141,6 +141,7 @@ export const loginCommand = new Command('login')
 
     let clientId = process.env.EWS_CLIENT_ID;
     mkdirSync(dirname(envPath), { recursive: true, mode: 0o700 });
+    chmodSync(dirname(envPath), 0o700);
     let envContent = '';
     if (existsSync(envPath)) {
       envContent = await readFile(envPath, 'utf8');

--- a/src/lib/atomic-write.ts
+++ b/src/lib/atomic-write.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from 'node:crypto';
-import { mkdir, rename, unlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, rename, unlink, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 
 /**
@@ -9,6 +9,10 @@ import { dirname, join } from 'node:path';
 export async function atomicWriteUtf8File(targetPath: string, data: string, mode: number): Promise<void> {
   const dir = dirname(targetPath);
   await mkdir(dir, { recursive: true, mode: 0o700 });
+  // `mkdir`'s `mode` only applies to directories it creates — a pre-existing dir (e.g. from an
+  // older CLI version with a looser default umask) keeps its prior permissions. Re-tighten it
+  // since this directory holds secret-bearing files.
+  await chmod(dir, 0o700).catch(() => {});
   const tmp = join(dir, `.${randomBytes(16).toString('hex')}.tmp`);
   try {
     await writeFile(tmp, data, { encoding: 'utf8', mode });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -16,7 +16,7 @@ import {
 function sanitizeRefreshError(raw: string | undefined | null): string {
   if (!raw) return '';
   return raw
-    .replace(/[\r\n\t\0]/g, ' ')
+    .replace(/\p{Cc}/gu, ' ')
     .replace(/\s+/g, ' ')
     .trim()
     .slice(0, 500);
@@ -40,6 +40,7 @@ async function refreshAccessToken(clientId: string, refreshToken: string, tenant
   ];
 
   let lastError = '';
+  let lastInteractionRequired = false;
 
   for (const scope of scopes) {
     const response = await fetch(`https://login.microsoftonline.com/${tenant}/oauth2/v2.0/token`, {
@@ -59,6 +60,8 @@ async function refreshAccessToken(clientId: string, refreshToken: string, tenant
       expires_in?: number;
       error?: string;
       error_description?: string;
+      error_codes?: number[];
+      suberror?: string;
     };
 
     if (response.ok && json.access_token) {
@@ -81,11 +84,20 @@ async function refreshAccessToken(clientId: string, refreshToken: string, tenant
     }
 
     lastError = [json.error, json.error_description].filter(Boolean).join(': ') || `HTTP ${response.status}`;
+    // AADSTS error code 500133 / sub error "interaction_required" means the user must re-authenticate
+    // (e.g. MFA, conditional access, or revoked grant). Track this so the caller can prompt re-login.
+    if (json.error === 'interaction_required' || (json.error_codes ?? []).includes(500133)) {
+      lastInteractionRequired = true;
+    }
   }
 
-  const error = new Error(`Token refresh failed: ${lastError}`) as Error & { lastRefreshError?: string };
+  const error = new Error(`Token refresh failed: ${lastError}`) as Error & {
+    lastRefreshError?: string;
+    interactionRequired?: boolean;
+  };
   // Preserve the most recent (last) OAuth error so callers can surface AADSTS / interaction_required details.
   error.lastRefreshError = sanitizeRefreshError(lastError);
+  error.interactionRequired = lastInteractionRequired;
   throw error;
 }
 
@@ -135,6 +147,7 @@ export async function resolveAuth(options?: {
     // can silently write rotated tokens to the default global .env.
     const activeEnvPath = getActiveEnvFilePath(options?.envPath);
     const lastRefreshErrors: string[] = [];
+    let interactionRequired = false;
 
     for (const rt of refreshTokens) {
       try {
@@ -159,6 +172,9 @@ export async function resolveAuth(options?: {
           err && typeof err === 'object' && 'lastRefreshError' in err
             ? (err as { lastRefreshError?: string }).lastRefreshError
             : undefined;
+        if (err && typeof err === 'object' && (err as { interactionRequired?: boolean }).interactionRequired) {
+          interactionRequired = true;
+        }
         lastRefreshErrors.push(sanitizeRefreshError(detailed || msg));
       }
     }
@@ -168,11 +184,15 @@ export async function resolveAuth(options?: {
     // re-resolves via getActiveEnvFilePath(options?.envPath) when envPath is omitted, so the
     // default path remains correct.
     const lastErrorDetail = lastRefreshErrors[lastRefreshErrors.length - 1] ?? '';
+    const interactiveHint = interactionRequired
+      ? ' Azure requires re-authentication (interaction_required / AADSTS500133). Run `m365-agent-cli login` again.'
+      : '';
     return {
       success: false,
       error:
         'Token refresh failed. Update M365_REFRESH_TOKEN (or GRAPH_REFRESH_TOKEN / EWS_REFRESH_TOKEN) in .env or run `login`.' +
-        (lastErrorDetail ? ` Last error: ${lastErrorDetail}` : ''),
+        (lastErrorDetail ? ` Last error: ${lastErrorDetail}` : '') +
+        interactiveHint,
       lastRefreshError: lastErrorDetail || undefined
     };
   } catch (err) {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,13 @@
 import { getActiveEnvFilePath } from './active-env.js';
 import { persistRefreshTokenToEnv } from './env-persist.js';
-import { getJwtExpiration, getMicrosoftTenantPathSegment, isValidJwtStructure } from './jwt-utils.js';
+import {
+  getJwtExpiration,
+  getJwtPayloadAppId,
+  getJwtPayloadTenantId,
+  getMicrosoftTenantPathSegment,
+  isPinnedTenantGuid,
+  isValidJwtStructure
+} from './jwt-utils.js';
 import {
   getUnifiedRefreshTokenFromEnv,
   loadM365TokenCache,
@@ -136,7 +143,26 @@ export async function resolveAuth(options?: {
     const cached = await loadM365TokenCache(identity);
     if (cached?.ews && cached.ews.expiresAt > Date.now() + 60_000) {
       if (isValidJwtStructure(cached.ews.accessToken)) {
-        return { success: true, token: cached.ews.accessToken };
+        const tokenAppId = getJwtPayloadAppId(cached.ews.accessToken);
+        const expectId = clientId.trim();
+        const appIdMismatch = tokenAppId && expectId && tokenAppId.toLowerCase() !== expectId.toLowerCase();
+        const tokenTenantId = getJwtPayloadTenantId(cached.ews.accessToken);
+        // Only enforce tenant equality when the operator pinned a concrete tenant GUID — `common` /
+        // `organizations` / `consumers` / domain-name tenants resolve to a `tid` that legitimately
+        // varies per user, so comparing those would produce false-positive refreshes.
+        const tenantMismatch =
+          isPinnedTenantGuid(tenant) && tokenTenantId && tokenTenantId.toLowerCase() !== tenant.toLowerCase();
+        if (appIdMismatch) {
+          console.warn(
+            `[auth] Ignoring cached EWS access token: token app id (${tokenAppId}) does not match EWS_CLIENT_ID (${expectId}). Refreshing.`
+          );
+        } else if (tenantMismatch) {
+          console.warn(
+            `[auth] Ignoring cached EWS access token: token tenant (${tokenTenantId}) does not match configured tenant (${tenant}). Refreshing.`
+          );
+        } else {
+          return { success: true, token: cached.ews.accessToken };
+        }
       }
     }
 

--- a/src/lib/graph-auth.ts
+++ b/src/lib/graph-auth.ts
@@ -5,7 +5,9 @@ import {
   getJwtExpiration,
   getJwtPayloadAppId,
   getJwtPayloadScopeSet,
+  getJwtPayloadTenantId,
   getMicrosoftTenantPathSegment,
+  isPinnedTenantGuid,
   isValidJwtStructure
 } from './jwt-utils.js';
 import {
@@ -152,10 +154,20 @@ export async function resolveGraphAuth(options?: {
       if (isValidJwtStructure(cached.graph.accessToken)) {
         const tokenAppId = getJwtPayloadAppId(cached.graph.accessToken);
         const expectId = clientId.trim();
-        const mismatch = tokenAppId && expectId && tokenAppId.toLowerCase() !== expectId.toLowerCase();
-        if (mismatch) {
+        const appIdMismatch = tokenAppId && expectId && tokenAppId.toLowerCase() !== expectId.toLowerCase();
+        const tokenTenantId = getJwtPayloadTenantId(cached.graph.accessToken);
+        // Only enforce tenant equality when the operator pinned a concrete tenant GUID — `common` /
+        // `organizations` / `consumers` / domain-name tenants resolve to a `tid` that legitimately
+        // varies per user, so comparing those would produce false-positive refreshes.
+        const tenantMismatch =
+          isPinnedTenantGuid(tenant) && tokenTenantId && tokenTenantId.toLowerCase() !== tenant.toLowerCase();
+        if (appIdMismatch) {
           console.warn(
             `[graph-auth] Ignoring cached Graph access token: token app id (${tokenAppId}) does not match EWS_CLIENT_ID (${expectId}). Refreshing.`
+          );
+        } else if (tenantMismatch) {
+          console.warn(
+            `[graph-auth] Ignoring cached Graph access token: token tenant (${tokenTenantId}) does not match configured tenant (${tenant}). Refreshing.`
           );
         } else {
           const scopeSet = getJwtPayloadScopeSet(cached.graph.accessToken);

--- a/src/lib/graph-auth.ts
+++ b/src/lib/graph-auth.ts
@@ -34,7 +34,7 @@ export interface GraphAuthResult {
 function sanitizeRefreshError(raw: string | undefined | null): string {
   if (!raw) return '';
   return raw
-    .replace(/[\r\n\t\0]/g, ' ')
+    .replace(/\p{Cc}/gu, ' ')
     .replace(/\s+/g, ' ')
     .trim()
     .slice(0, 500);

--- a/src/lib/jwt-utils.test.ts
+++ b/src/lib/jwt-utils.test.ts
@@ -3,7 +3,9 @@ import { Buffer } from 'node:buffer';
 import {
   getJwtPayloadAppId,
   getJwtPayloadScopeSet,
+  getJwtPayloadTenantId,
   getMicrosoftTenantPathSegment,
+  isPinnedTenantGuid,
   isValidJwtStructure,
   resolveTenantPathSegment
 } from './jwt-utils.js';
@@ -25,6 +27,43 @@ describe('getJwtPayloadAppId', () => {
 
   test('returns undefined for malformed token', () => {
     expect(getJwtPayloadAppId('not-a-jwt')).toBeUndefined();
+  });
+});
+
+describe('getJwtPayloadTenantId', () => {
+  test('reads tid from payload', () => {
+    const h = Buffer.from(JSON.stringify({ alg: 'none' })).toString('base64url');
+    const p = Buffer.from(JSON.stringify({ tid: '11111111-2222-4333-8444-555555555555' })).toString('base64url');
+    const tok = `${h}.${p}.x`;
+    expect(getJwtPayloadTenantId(tok)).toBe('11111111-2222-4333-8444-555555555555');
+  });
+
+  test('returns undefined when tid is absent or malformed', () => {
+    const h = Buffer.from(JSON.stringify({ alg: 'none' })).toString('base64url');
+    const p = Buffer.from(JSON.stringify({ appid: 'x' })).toString('base64url');
+    expect(getJwtPayloadTenantId(`${h}.${p}.x`)).toBeUndefined();
+    expect(getJwtPayloadTenantId('not-a-jwt')).toBeUndefined();
+  });
+});
+
+describe('isPinnedTenantGuid', () => {
+  test('accepts a well-formed tenant GUID', () => {
+    expect(isPinnedTenantGuid('11111111-2222-4333-8444-555555555555')).toBe(true);
+  });
+
+  test('rejects the common/organizations/consumers placeholders', () => {
+    expect(isPinnedTenantGuid('common')).toBe(false);
+    expect(isPinnedTenantGuid('organizations')).toBe(false);
+    expect(isPinnedTenantGuid('consumers')).toBe(false);
+  });
+
+  test('rejects a domain-name tenant', () => {
+    expect(isPinnedTenantGuid('contoso.onmicrosoft.com')).toBe(false);
+  });
+
+  test('rejects a malformed GUID-shaped string', () => {
+    expect(isPinnedTenantGuid('not-a-guid')).toBe(false);
+    expect(isPinnedTenantGuid('11111111-2222-3333-4444-555555555555')).toBe(false); // bad version/variant nibbles
   });
 });
 

--- a/src/lib/jwt-utils.ts
+++ b/src/lib/jwt-utils.ts
@@ -94,6 +94,31 @@ export function getJwtPayloadAppId(token: string): string | undefined {
   }
 }
 
+/** Tenant id embedded in an access token (`tid` claim). */
+export function getJwtPayloadTenantId(token: string): string | undefined {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return undefined;
+    const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8')) as { tid?: string };
+    if (typeof payload.tid === 'string' && payload.tid.length > 0) return payload.tid;
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+const TENANT_GUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/;
+
+/**
+ * True when `tenant` is a concrete tenant GUID (as opposed to the `common`/`organizations`/`consumers`
+ * placeholders or a domain name, none of which ever appear as a token's `tid` claim). Used to gate
+ * cached-token tenant-mismatch checks: only enforce `tid` equality when the operator pinned a specific
+ * tenant, since placeholder/domain tenants resolve to a `tid` that legitimately varies per user.
+ */
+export function isPinnedTenantGuid(tenant: string): boolean {
+  return TENANT_GUID_RE.test(tenant);
+}
+
 /** Space-separated delegated scopes on a Graph access token (`scp` claim). */
 export function getJwtPayloadScopeSet(token: string): Set<string> {
   try {

--- a/src/lib/m365-token-cache.test.ts
+++ b/src/lib/m365-token-cache.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, test } from 'bun:test';
-import { assertValidCacheIdentity } from './m365-token-cache.js';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { assertValidCacheIdentity, loadM365TokenCache } from './m365-token-cache.js';
 
 describe('assertValidCacheIdentity', () => {
   test('accepts default and common ids', () => {
@@ -16,5 +19,43 @@ describe('assertValidCacheIdentity', () => {
     expect(() => assertValidCacheIdentity('')).toThrow(/Invalid token cache identity/);
     expect(() => assertValidCacheIdentity('   ')).toThrow(/Invalid token cache identity/);
     expect(() => assertValidCacheIdentity('x'.repeat(129))).toThrow(/Invalid token cache identity/);
+  });
+});
+
+describe('legacy cache migration re-tightens permissions', () => {
+  let testHome: string;
+  let originalConfigDir: string | undefined;
+
+  beforeEach(async () => {
+    testHome = await mkdtemp(join(tmpdir(), 'm365-token-cache-migrate-'));
+    originalConfigDir = process.env.M365_AGENT_CLI_CONFIG_DIR;
+    process.env.M365_AGENT_CLI_CONFIG_DIR = join(testHome, '.config', 'm365-agent-cli');
+  });
+
+  afterEach(async () => {
+    if (originalConfigDir === undefined) {
+      delete process.env.M365_AGENT_CLI_CONFIG_DIR;
+    } else {
+      process.env.M365_AGENT_CLI_CONFIG_DIR = originalConfigDir;
+    }
+    await rm(testHome, { recursive: true, force: true }).catch(() => {});
+  });
+
+  test('root graph-token-cache.json migrated from a loosely-permissioned file ends up 0600', async () => {
+    const dir = process.env.M365_AGENT_CLI_CONFIG_DIR as string;
+    await mkdir(dir, { recursive: true });
+    const legacyPath = join(dir, 'graph-token-cache.json');
+    // Simulate a pre-hardening file created under a permissive umask (world/group readable).
+    await writeFile(
+      legacyPath,
+      JSON.stringify({ version: 1, refreshToken: 'rt', graph: { accessToken: 'a.b.c', expiresAt: Date.now() } }),
+      { mode: 0o644 }
+    );
+
+    await loadM365TokenCache('default');
+
+    const migratedPath = join(dir, 'graph-token-cache-default.json');
+    const s = await stat(migratedPath);
+    expect(s.mode & 0o777).toBe(0o600);
   });
 });

--- a/src/lib/m365-token-cache.ts
+++ b/src/lib/m365-token-cache.ts
@@ -2,7 +2,7 @@
  * Unified OAuth token cache: one file per identity with separate EWS and Graph access tokens
  * (different audiences) and a single refresh token. See docs/GOALS.md.
  */
-import { mkdir, readFile, rename, stat, unlink } from 'node:fs/promises';
+import { chmod, mkdir, readFile, rename, stat, unlink } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { atomicWriteUtf8File } from './atomic-write.js';
@@ -205,14 +205,19 @@ async function migrateLegacyGraphRootFiles(): Promise<void> {
       const legacyStats = await stat(rootLegacy).catch(() => null);
       if (legacyStats) {
         await mkdir(configDir(), { recursive: true, mode: 0o700 });
+        await chmod(configDir(), 0o700).catch(() => {});
         await rename(rootLegacy, defaultPath);
+        // `rename` preserves the source file's mode, which may predate 0600 hardening — re-tighten it.
+        await chmod(defaultPath, 0o600).catch(() => {});
         return;
       }
       const clippyGraph = legacyClippyGraphCacheFile();
       const oldClippyStats = await stat(clippyGraph).catch(() => null);
       if (oldClippyStats) {
         await mkdir(configDir(), { recursive: true, mode: 0o700 });
+        await chmod(configDir(), 0o700).catch(() => {});
         await rename(clippyGraph, defaultPath);
+        await chmod(defaultPath, 0o600).catch(() => {});
       }
     }
   } catch {
@@ -232,7 +237,10 @@ async function migrateLegacyEwsClippyCache(identity: string): Promise<void> {
     if (!legacyStats) return;
 
     await mkdir(configDir(), { recursive: true, mode: 0o700 });
+    await chmod(configDir(), 0o700).catch(() => {});
     await rename(legacy, dest);
+    // `rename` preserves the source file's mode, which may predate 0600 hardening — re-tighten it.
+    await chmod(dest, 0o600).catch(() => {});
   } catch {
     // ignore
   }

--- a/src/test/auth.test.ts
+++ b/src/test/auth.test.ts
@@ -98,6 +98,41 @@ describe('auth resolution', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  test('ignores cached EWS token when app id does not match EWS_CLIENT_ID', async () => {
+    // Mirrors graph-auth.test.ts's "ignores cached Graph token when app id does not match
+    // EWS_CLIENT_ID": the EWS path lacked this binding check and could silently serve a
+    // token minted for a different Entra app registration after EWS_CLIENT_ID changes.
+    process.env.EWS_CLIENT_ID = '5f2abcea-d6ea-4460-b468-3d80d7a900eb';
+    process.env.M365_REFRESH_TOKEN = 'env-refresh';
+
+    function ewsFixtureAccessTokenWithAppId(appid: string): string {
+      const h = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+      const p = Buffer.from(JSON.stringify({ exp: 2_000_000_000, appid })).toString('base64url');
+      return `${h}.${p}.x`;
+    }
+
+    await writePrimaryCache(testHome, cacheIdentity, {
+      version: 1,
+      refreshToken: 'cached-refresh-token',
+      ews: {
+        accessToken: ewsFixtureAccessTokenWithAppId('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+        expiresAt: Date.now() + 1000_000
+      }
+    });
+
+    const newTok = ewsFixtureAccessTokenWithAppId('5f2abcea-d6ea-4460-b468-3d80d7a900eb');
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ access_token: newTok, refresh_token: 'rotated', expires_in: 3600 }), {
+        status: 200
+      })
+    );
+
+    const result = await resolveAuth({ identity: cacheIdentity });
+    expect(result.success).toBe(true);
+    expect(result.token).toBe(newTok);
+    expect(mockFetch).toHaveBeenCalled();
+  });
+
   test('accepts legacy flat EWS cache shape', async () => {
     process.env.EWS_CLIENT_ID = 'client';
     process.env.EWS_REFRESH_TOKEN = 'refresh';

--- a/src/test/auth.test.ts
+++ b/src/test/auth.test.ts
@@ -203,6 +203,39 @@ describe('auth resolution', () => {
     expect(result.lastRefreshError ?? '').not.toContain('expired-rt');
   });
 
+  test('surfaces interaction_required / AADSTS500133 re-authentication hint on EWS refresh failure (M-1)', async () => {
+    process.env.EWS_CLIENT_ID = 'client';
+    process.env.M365_REFRESH_TOKEN = 'expired-rt';
+
+    await writePrimaryCache(testHome, cacheIdentity, {
+      version: 1,
+      ews: { accessToken: ewsFixtureAccessToken('expired'), expiresAt: Date.now() - 1000_000 }
+    });
+
+    // EWS refresh tries two scopes in a loop, so provide a fresh Response on each call.
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            error: 'interaction_required',
+            error_description: 'AADSTS500133: Assertion is not within its valid time range.',
+            error_codes: [500133]
+          }),
+          { status: 400 }
+        )
+      )
+    );
+
+    const result = await resolveAuth({ identity: cacheIdentity });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('AADSTS500133');
+    expect(result.error).toContain('interaction_required');
+    expect(result.error).toContain('re-authentication');
+    expect(result.lastRefreshError).toContain('AADSTS500133');
+    // Secrets guard
+    expect(result.lastRefreshError ?? '').not.toContain('expired-rt');
+  });
+
   test('persists rotated refresh token to caller-provided envPath (H-1/H-2 EWS)', async () => {
     const envHome = await mkdtemp(join(tmpdir(), 'm365-auth-envpath-'));
     try {

--- a/src/test/graph-auth.test.ts
+++ b/src/test/graph-auth.test.ts
@@ -117,10 +117,11 @@ describe('resolveGraphAuth', () => {
     expect(r.error).toContain('Invalid identity');
   });
 
-  function makeAccessTokenJwt(appid: string, scp?: string): string {
+  function makeAccessTokenJwt(appid: string, scp?: string, tid?: string): string {
     const h = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
     const payload: Record<string, unknown> = { appid, exp: 2_000_000_000 };
     if (scp !== undefined) payload.scp = scp;
+    if (tid !== undefined) payload.tid = tid;
     const p = Buffer.from(JSON.stringify(payload)).toString('base64url');
     return `${h}.${p}.x`;
   }
@@ -160,6 +161,55 @@ describe('resolveGraphAuth', () => {
     expect(r.success).toBe(true);
     expect(mockFetch).toHaveBeenCalled();
     expect(mockSave).toHaveBeenCalled();
+  });
+
+  test('ignores cached Graph token when tenant does not match a pinned tenant GUID', async () => {
+    // `getMicrosoftTenantPathSegment` is forced to a concrete tenant GUID for this test only, so the
+    // new `isPinnedTenantGuid` gate engages (it's a no-op for the default 'common' used elsewhere).
+    const pinnedTenant = '11111111-2222-4333-8444-555555555555';
+    const staleTenant = '66666666-7777-8888-9999-000000000000';
+    mock.module('../lib/jwt-utils.js', () => ({
+      ...jwtUtilsReal,
+      getMicrosoftTenantPathSegment: mock(() => pinnedTenant)
+    }));
+    const pinnedMod = await import(`../lib/graph-auth.js?graphAuthTenantTest=${Date.now()}`);
+    const resolveGraphAuthPinned: typeof resolveGraphAuth = pinnedMod.resolveGraphAuth;
+
+    process.env.EWS_CLIENT_ID = '5f2abcea-d6ea-4460-b468-3d80d7a900eb';
+    process.env.M365_REFRESH_TOKEN = 'env-refresh';
+
+    mockLoad.mockResolvedValue({
+      version: 1,
+      graph: {
+        accessToken: makeAccessTokenJwt(
+          '5f2abcea-d6ea-4460-b468-3d80d7a900eb',
+          'Mail.ReadWrite Calendars.ReadWrite User.Read',
+          staleTenant
+        ),
+        expiresAt: Date.now() + 3_600_000
+      }
+    } as never);
+
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            access_token: makeAccessTokenJwt(
+              '5f2abcea-d6ea-4460-b468-3d80d7a900eb',
+              'Mail.Send Mail.ReadWrite Contacts.ReadWrite Notes.ReadWrite.All OnlineMeetings.ReadWrite User.Read',
+              pinnedTenant
+            ),
+            refresh_token: 'rotated',
+            expires_in: 3600
+          }),
+          { status: 200 }
+        )
+      )
+    );
+
+    const r = await resolveGraphAuthPinned();
+    expect(r.success).toBe(true);
+    expect(mockFetch).toHaveBeenCalled();
   });
 
   test('ignores cached Graph token when critical scopes are missing (narrow token)', async () => {


### PR DESCRIPTION
## Summary

Follow-up fixes found during a full code review of #232 (auth/token handling hardening), which merged before this review completed. Two commits of fixes:

### Commit 1 — EWS interaction_required parity, sanitizer hardening
- **EWS refresh path was missing `interaction_required`/AADSTS 500133 detection.** `resolveGraphAuth` (Graph path) already surfaced a re-authentication hint when Azure returns `interaction_required`, but `resolveAuth` (EWS path) did not — despite #232's own changelog claiming both `AuthResult` and `GraphAuthResult` got this treatment. `refreshAccessToken`/`resolveAuth` in `src/lib/auth.ts` now mirror the same detection/accumulation logic already in `src/lib/graph-auth.ts`.
- **`sanitizeRefreshError` doc/implementation mismatch.** Its doc comment claimed to strip "control characters" but the regex only handled `\r\n\t\0`. Changed to `\p{Cc}` (full Unicode control-character category) in both `src/lib/auth.ts` and `src/lib/graph-auth.ts`.

### Commit 2 — cache-migration permission hardening, cached-token app/tenant binding
Found during a wider review of the full auth/token-handling solution (not just the diff):
- **Legacy cache migration didn't re-tighten file permissions.** `migrateLegacyGraphRootFiles`/`migrateLegacyEwsClippyCache` in `src/lib/m365-token-cache.ts` used `rename()`, which preserves the source file's mode — a pre-hardening file with loose permissions stayed loose after migration until the next save. Now `chmod`s the migrated file to 0600 and the config dir to 0700 on every creation path (`atomic-write.ts`, `m365-token-cache.ts`, `login.ts`), since `mkdir`'s `mode` only applies to directories it actually creates.
- **EWS cached-token reuse didn't check the token's `appid` claim against `EWS_CLIENT_ID`**, unlike the Graph path, so switching client IDs while reusing the same cache identity could silently serve a token minted for a different Entra app. Added the same binding check to the EWS path.
- **Neither path validated the token's `tid` claim against the configured tenant.** Added a narrow, low-risk check: only enforce `tid` equality when the operator pinned a concrete tenant GUID (not the `common`/`organizations`/`consumers` placeholders or a domain name, none of which ever appear as a real `tid`), via new `isPinnedTenantGuid`/`getJwtPayloadTenantId` helpers in `jwt-utils.ts`.
- **`login.ts`'s device-code flow parsed the access token with a raw split/`JSON.parse`** instead of `isValidJwtStructure` like every other consumer; aligned for consistency.

## Tests

- New/updated regression tests for all of the above, including a migration-permission test in `m365-token-cache.test.ts`, app-id/tenant-mismatch tests in `auth.test.ts`/`graph-auth.test.ts`, and pure unit tests for the new `jwt-utils.ts` helpers.
- `bun test --isolate` → 570 / 570 pass (66 files), verified stable across repeated runs
- `bun run typecheck` → clean
- `bun run lint` → clean (biome)
- `bun run format:check` → clean (biome)

## Backwards compatibility

No public API shape changes. Cached-token reuse becomes slightly stricter (an EWS token whose `appid`/`tid` no longer matches the current config now triggers a refresh instead of being reused) — this only affects the narrow case of reconfiguring `EWS_CLIENT_ID` or a pinned tenant GUID while reusing the same cache identity, and self-heals via the existing refresh flow.
