### PR TITLE
ci(release): auto-tag and release on green CI for a new version on main

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,61 @@
+# Cuts a release automatically once CI is green on `main` for a commit that bumped
+# package.json's version and that version has no release tag yet (e.g. a merged
+# "chore(release): X" PR per docs/RELEASE.md). No-ops on every other green CI run on main.
+#
+# Tags are created with the default GITHUB_TOKEN, which does not itself trigger the
+# `push: tags` listener in release.yml (GITHUB_TOKEN-authored pushes don't cascade
+# other workflow triggers) — so this workflow explicitly dispatches release.yml afterward.
+
+name: Auto Release
+
+on:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  tag-and-dispatch:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Check whether this version is already released
+        id: version
+        run: |
+          set -e
+          VER=$(node -p "require('./package.json').version")
+          TAG="v$VER"
+          if git ls-remote --tags origin "refs/tags/$TAG" | grep -q "refs/tags/$TAG$"; then
+            echo "Tag $TAG already exists — nothing new to release."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "New version $VER on main with no $TAG tag yet — cutting a release."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push release tag
+        if: steps.version.outputs.exists == 'false'
+        run: |
+          set -e
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git tag "${{ steps.version.outputs.tag }}" "${{ github.event.workflow_run.head_sha }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+
+      - name: Dispatch release workflow
+        if: steps.version.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run release.yml --ref "${{ steps.version.outputs.tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@
 # Optional: add repository secret NPM_TOKEN (granular publish token) if OIDC publish still fails; the publish step uses it when set.
 # See: https://docs.npmjs.com/trusted-publishers
 # Tag must match package.json version exactly (e.g. tag v2026.4.50 and "version": "2026.4.50").
+#
+# workflow_dispatch lets auto-release.yml (or a maintainer) run this against an existing tag ref
+# without a local `git push origin vX.Y.Z` — tags created by the default GITHUB_TOKEN don't
+# themselves fire the `push: tags` trigger below, so that workflow dispatches this one explicitly.
 
 name: Release
 
@@ -11,6 +15,9 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  # Dispatch with `--ref vX.Y.Z` (an existing tag) — GITHUB_REF inside the job then reads
+  # refs/tags/vX.Y.Z exactly as it would on a real tag push, so the verify step below is unchanged.
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -51,11 +51,19 @@ If the package name is already taken on npm, you must rename the package in `pac
 
 ## Cutting a release
 
+Releases are cut automatically — see **Automatic releases** below. You only need to do this manually if automation is disabled or you're releasing from a branch other than `main`.
+
 1. On `main` (or your release branch), set **`version`** in `package.json` to the new version (semver or calendar-style, e.g. `2026.4.50`). Update **`CHANGELOG.md`** for the release. Run **`npm run sync-skill`** so `skills/m365-agent-cli/SKILL.md` frontmatter `version:` matches the package (OpenClaw/ClawHub skill metadata). Commit, for example: `chore(release): 2026.4.50`.
 2. Tag that commit: `git tag v2026.4.50` (the tag **must** be `v` + the exact version string from `package.json`).
 3. Push the tag: `git push origin v2026.4.50` (and push the commit to `main` if needed).
 
 Pushing the tag runs **Release** in GitHub Actions (see [`.github/workflows/release.yml`](../.github/workflows/release.yml)): it checks that the tag matches `package.json`, runs checks, runs **`npm run embed-sha`**, publishes to npm with **`npm publish --access public`** (Trusted Publishing OIDC when **`NPM_TOKEN`** is unset), and creates a GitHub Release (with auto-generated notes; you can paste from **`CHANGELOG.md`** if you want richer text).
+
+## Automatic releases
+
+[`.github/workflows/auto-release.yml`](../.github/workflows/auto-release.yml) watches every **CI** run on `main`. When CI finishes green and `package.json`'s `version` has no matching `vX.Y.Z` tag yet, it creates that tag on the green commit and dispatches **Release** (via `workflow_dispatch`, since the default `GITHUB_TOKEN` used to push the tag doesn't itself fire the `push: tags` trigger — see the comments in both workflow files). Every other green CI run on `main` (no version bump) is a no-op.
+
+In practice: merge a `chore(release): X` PR (step 1 above, without steps 2–3) to `main`, and once CI passes the release ships on its own — no local tag push needed. Steps 2–3 above remain available as a manual fallback (e.g. from an environment without push access to trigger Actions, or to release a commit that isn't `main`'s tip).
 
 ## After publish
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/auto-release.yml`: after every **CI** run on `main` completes green, it checks whether `package.json`'s current `version` already has a matching `vX.Y.Z` tag. If not (i.e. the just-merged commit bumped the version, per the `chore(release): X` convention in `docs/RELEASE.md`), it tags that commit and dispatches **Release**. Every other green CI run on `main` (no version bump) is a no-op.
- `release.yml` gains a `workflow_dispatch` trigger so it can be invoked against an existing tag (`--ref vX.Y.Z`) without a real tag-push event — needed because a tag pushed by the default `GITHUB_TOKEN` does not itself fire another workflow's `push: tags` trigger (a GitHub Actions anti-recursion rule). No other change to `release.yml`'s logic; `GITHUB_REF` inside the dispatched run reads the same `refs/tags/vX.Y.Z` it would on a real push, so the existing tag/`package.json` verification step is untouched.
- `docs/RELEASE.md` documents the new automatic flow and keeps the manual `git tag` + `git push` steps as a documented fallback.

## Why
Previously, cutting a release required a human (or an agent with tag-push rights) to run `git tag vX.Y.Z && git push origin vX.Y.Z` after merging a version-bump PR. This automates that last step: merge the release-prep PR, and once CI is green on `main` the release ships on its own.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open(f))"` on both changed/added workflow files — valid YAML.
- [ ] After merge: confirm `auto-release.yml` fires on the next green `main` CI run and correctly no-ops (no version bump yet on `main`).
- [ ] Next real version bump merged to `main`: confirm it tags `vX.Y.Z`, dispatches `release.yml`, and the release completes (npm publish + GitHub Release).


---
_Generated by [Claude Code](https://claude.ai/code/session_01C4rxJ9JfaQGqjEYoHwjjyA)_