### PR TITLE
Fix update-event Graph --all-day drop, unnormalized event times, and data-loss bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ For install and tagging, see [docs/RELEASE.md](docs/RELEASE.md).
 
 ---
 
+## [2026.7.6] — 2026-07-13
+
+### Fixed
+
+Follow-up QA-review fixes found after 2026.7.5 shipped:
+
+- **`update-event` (Graph path) silently dropped `--all-day`/`--no-all-day`.** An edit earlier in the same review pass accidentally removed `allDay: options.allDay` from the Graph PATCH-building call; if `--all-day` was the only flag given, the command now hit a spurious "No field updates to apply" error, and if combined with another change, the command reported success while leaving the event's all-day flag unchanged.
+- **`update-event`/`delete-event` still showed the wrong event time on non-UTC hosts in several display/JSON paths.** The earlier fix for Graph's zone-less `dateTime` covered the PATCH-building computation but missed the event-listing, occurrence-selection, and post-update confirmation display paths, which still read `start`/`end` raw. All remaining call sites now go through the same normalization.
+- **`oof` could silently disable a live out-of-office reply.** Updating only `--internal-message`/`--external-message` fetches the current settings first to preserve status/schedule across the partial update; if that fetch failed (throttling, network blip), the code defaulted to `status: 'disabled'` instead of aborting, turning off OOF as a side effect of an unrelated text edit.
+- **`suggest --days 0` was silently treated as the default of 5** (`parseInt(...) || 5` mistook the falsy `0` for "not provided"), and negative values weren't rejected, which could send Graph an inverted time window. `--days` is now validated as a non-negative integer.
+
+---
+
 ## [2026.7.5] — 2026-07-12
 
 ### Added (feature roadmap)

--- a/docs/GRAPH_PATH_INVENTORY.json
+++ b/docs/GRAPH_PATH_INVENTORY.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "description": "Graph path patterns from static analysis of callGraph*, graphInvoke*, fetchAllPages, fetchGraphRaw, graphPostBatch. Regenerate: npm run graph:inventory",
-  "generatedAt": "2026-07-12T20:08:11.901Z",
+  "generatedAt": "2026-07-13T06:15:49.741Z",
   "entryCount": 713,
   "entries": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "m365-agent-cli",
-  "version": "2026.7.5",
+  "version": "2026.7.6",
   "description": "Microsoft 365 from your terminal: calendar, mail, OneDrive, Planner, Teams, Graph \u2014 one OAuth login",
   "repository": {
     "type": "git",

--- a/skills/m365-agent-cli/SKILL.md
+++ b/skills/m365-agent-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: m365-agent-cli
-version: 2026.7.5
+version: 2026.7.6
 description: Microsoft 365 CLI (EWS + Graph) for calendar, mail, OneDrive, Planner, SharePoint, To Do, Teams, Bookings, Excel-on-drive, presence, inbox rules, delegates, subscriptions, Graph Search, Microsoft Viva / employee experience (`viva` — Graph beta: tenant `/employeeExperience`, user work time/insights/roles/learning, admin+org itemInsights, workHoursAndLocations, meeting Engage Q&A), Microsoft 365 Copilot APIs (`copilot` — retrieval, search, chat, reports, packages, meeting insights, interaction export, notify-help), and raw `graph invoke`/`graph batch`. Use when the user needs Outlook/Exchange, Graph, or M365 automation from the terminal.
 # `version` matches the npm CLI release; run `npm run sync-skill` after bumping package.json.
 metadata:

--- a/src/commands/delete-event.ts
+++ b/src/commands/delete-event.ts
@@ -18,6 +18,7 @@ import {
   listCalendarView
 } from '../lib/graph-calendar-client.js';
 import { truncateRecurringSeriesBeforeCut } from '../lib/graph-calendar-recurrence.js';
+import { normalizeGraphDateTimeForParsing } from '../lib/graph-datetime.js';
 import { toJsonError } from '../lib/json-error.js';
 import { checkReadOnly } from '../lib/utils.js';
 
@@ -32,7 +33,11 @@ function formatDate(dateStr: string): string {
 }
 
 function graphStartDt(e: GraphCalendarEvent): string {
-  return e.start?.dateTime ?? '';
+  return normalizeGraphDateTimeForParsing(e.start?.dateTime, e.start?.timeZone);
+}
+
+function graphEndDt(e: GraphCalendarEvent): string {
+  return normalizeGraphDateTimeForParsing(e.end?.dateTime, e.end?.timeZone);
 }
 
 export const deleteEventCommand = new Command('delete-event')
@@ -197,7 +202,7 @@ export const deleteEventCommand = new Command('delete-event')
                     id: (e as GraphCalendarEvent).id,
                     subject: (e as GraphCalendarEvent).subject,
                     start: graphStartDt(e as GraphCalendarEvent),
-                    end: (e as GraphCalendarEvent).end?.dateTime
+                    end: graphEndDt(e as GraphCalendarEvent)
                   }))
                 },
                 null,
@@ -239,7 +244,7 @@ export const deleteEventCommand = new Command('delete-event')
           if (useGraph) {
             const ge = event as GraphCalendarEvent;
             const st = graphStartDt(ge);
-            const en = ge.end?.dateTime ?? '';
+            const en = graphEndDt(ge);
             const startTime = formatTime(st);
             const endTime = formatTime(en);
             const ac = graphNonResourceAttendeeCount(ge);
@@ -367,7 +372,7 @@ export const deleteEventCommand = new Command('delete-event')
               console.log(`\nDeleting single occurrence: ${targetGraph.subject ?? '(no subject)'}`);
             }
             console.log(
-              `  ${formatDate(graphStartDt(targetGraph))} ${formatTime(graphStartDt(targetGraph))} - ${formatTime(targetGraph.end?.dateTime ?? '')}`
+              `  ${formatDate(graphStartDt(targetGraph))} ${formatTime(graphStartDt(targetGraph))} - ${formatTime(graphEndDt(targetGraph))}`
             );
           }
         } else if (!targetGraph) {
@@ -384,14 +389,14 @@ export const deleteEventCommand = new Command('delete-event')
           if (!options.json) {
             console.log(`\nDeleting: ${targetGraph.subject ?? '(no subject)'}`);
             console.log(
-              `  ${formatDate(graphStartDt(targetGraph))} ${formatTime(graphStartDt(targetGraph))} - ${formatTime(targetGraph.end?.dateTime ?? '')}`
+              `  ${formatDate(graphStartDt(targetGraph))} ${formatTime(graphStartDt(targetGraph))} - ${formatTime(graphEndDt(targetGraph))}`
             );
           }
         } else {
           if (!options.json) {
             console.log(`\nDeleting: ${targetGraph.subject ?? '(no subject)'} (scope: ${scope})`);
             console.log(
-              `  ${formatDate(graphStartDt(targetGraph))} ${formatTime(graphStartDt(targetGraph))} - ${formatTime(targetGraph.end?.dateTime ?? '')}`
+              `  ${formatDate(graphStartDt(targetGraph))} ${formatTime(graphStartDt(targetGraph))} - ${formatTime(graphEndDt(targetGraph))}`
             );
           }
         }

--- a/src/commands/oof.ts
+++ b/src/commands/oof.ts
@@ -178,7 +178,19 @@ export const oofCommand = new Command('oof')
     if (!status && (options.internalMessage !== undefined || options.externalMessage !== undefined)) {
       statusWasUndefined = true;
       const currentRes = await getMailboxSettings(token, options.user);
-      if (currentRes.ok && currentRes.data?.automaticRepliesSetting) {
+      if (!currentRes.ok) {
+        // Don't guess: if the fetch itself failed (throttling, network blip, etc.), defaulting to
+        // 'disabled' here would silently turn off a live out-of-office reply as a side effect of
+        // an unrelated --internal-message/--external-message edit.
+        const msg = currentRes.error?.message || 'Failed to fetch current mailbox settings';
+        if (options.json) {
+          console.log(JSON.stringify({ error: toJsonError(msg) }, null, 2));
+        } else {
+          console.error(`Error: ${msg}`);
+        }
+        process.exit(1);
+      }
+      if (currentRes.data?.automaticRepliesSetting) {
         status = currentRes.data.automaticRepliesSetting.status;
         if (status === 'scheduled') {
           scheduledStartDateTime =
@@ -186,7 +198,7 @@ export const oofCommand = new Command('oof')
           scheduledEndDateTime = scheduledEndDateTime ?? currentRes.data.automaticRepliesSetting.scheduledEndDateTime;
         }
       } else {
-        status = 'disabled'; // fallback if we couldn't fetch
+        status = 'disabled'; // fetch succeeded; no automaticRepliesSetting configured yet
       }
     }
 

--- a/src/commands/suggest.ts
+++ b/src/commands/suggest.ts
@@ -75,7 +75,16 @@ export const suggestCommand = new Command('suggest')
       }
 
       const durationStr = durationMapping[durationKey];
-      const days = parseInt(options.days, 10) || 5;
+      const days = parseInt(options.days, 10);
+      if (Number.isNaN(days) || days < 0) {
+        const message = `Invalid --days "${options.days}". Must be a non-negative integer.`;
+        if (options.json) {
+          console.log(JSON.stringify({ error: toJsonError(message) }, null, 2));
+        } else {
+          console.error(`Error: ${message}`);
+        }
+        process.exit(1);
+      }
 
       const startDateTime = new Date();
       const endDateTime = new Date(startDateTime);

--- a/src/commands/update-event.ts
+++ b/src/commands/update-event.ts
@@ -55,7 +55,11 @@ function formatDate(dateStr: string): string {
 }
 
 function graphStartDt(e: GraphCalendarEvent): string {
-  return e.start?.dateTime ?? '';
+  return normalizeGraphDateTimeForParsing(e.start?.dateTime, e.start?.timeZone);
+}
+
+function graphEndDt(e: GraphCalendarEvent): string {
+  return normalizeGraphDateTimeForParsing(e.end?.dateTime, e.end?.timeZone);
 }
 
 export const updateEventCommand = new Command('update-event')
@@ -279,7 +283,7 @@ export const updateEventCommand = new Command('update-event')
                     id: (e as GraphCalendarEvent).id,
                     subject: (e as GraphCalendarEvent).subject,
                     start: graphStartDt(e as GraphCalendarEvent),
-                    end: (e as GraphCalendarEvent).end?.dateTime
+                    end: graphEndDt(e as GraphCalendarEvent)
                   }))
                 },
                 null,
@@ -322,7 +326,7 @@ export const updateEventCommand = new Command('update-event')
           if (useGraph) {
             const ge = event as GraphCalendarEvent;
             const st = graphStartDt(ge);
-            const en = ge.end?.dateTime ?? '';
+            const en = graphEndDt(ge);
             console.log(`\n  [${i + 1}] ${ge.subject ?? '(no subject)'}`);
             console.log(`      ${formatTime(st)} - ${formatTime(en)}`);
             console.log(`      ID: ${ge.id}`);
@@ -438,7 +442,7 @@ export const updateEventCommand = new Command('update-event')
             if (!options.json) {
               console.log(`\nUpdating single occurrence of: ${occEvent.subject ?? '(no subject)'}`);
               console.log(
-                `  ${formatDate(graphStartDt(occEvent))} ${formatTime(graphStartDt(occEvent))} - ${formatTime(occEvent.end?.dateTime ?? '')}`
+                `  ${formatDate(graphStartDt(occEvent))} ${formatTime(graphStartDt(occEvent))} - ${formatTime(graphEndDt(occEvent))}`
               );
             }
           } else if (options.occurrence) {
@@ -456,7 +460,7 @@ export const updateEventCommand = new Command('update-event')
             if (!options.json) {
               console.log(`\nUpdating occurrence ${idx} of: ${occEvent.subject ?? '(no subject)'}`);
               console.log(
-                `  ${formatDate(graphStartDt(occEvent))} ${formatTime(graphStartDt(occEvent))} - ${formatTime(occEvent.end?.dateTime ?? '')}`
+                `  ${formatDate(graphStartDt(occEvent))} ${formatTime(graphStartDt(occEvent))} - ${formatTime(graphEndDt(occEvent))}`
               );
             }
           }
@@ -558,7 +562,7 @@ export const updateEventCommand = new Command('update-event')
         if (useGraph && targetGraph) {
           const tg = targetGraph;
           const st = graphStartDt(tg);
-          const en = tg.end?.dateTime ?? '';
+          const en = graphEndDt(tg);
           console.log(`\nEvent: ${tg.subject ?? '(no subject)'}`);
           console.log(`  When: ${formatDate(st)} ${formatTime(st)} - ${formatTime(en)}`);
           if (tg.location?.displayName) {
@@ -894,6 +898,7 @@ export const updateEventCommand = new Command('update-event')
                 location: graphLocationsPatch?.length ? undefined : locationText,
                 graphLocations: graphLocationsPatch,
                 showAs: showAsPatch,
+                allDay: options.allDay,
                 sensitivity: sensitivityEws,
                 categories: options.category && options.category.length > 0 ? options.category : undefined,
                 clearCategories: options.clearCategories,
@@ -996,8 +1001,8 @@ export const updateEventCommand = new Command('update-event')
                             id: ur.data.id,
                             changeKey: ur.data.changeKey,
                             subject: ur.data.subject,
-                            start: ur.data.start?.dateTime,
-                            end: ur.data.end?.dateTime
+                            start: graphStartDt(ur.data),
+                            end: graphEndDt(ur.data)
                           },
                           fileAttachmentsAdded: files.length,
                           referenceAttachmentsAdded: links.length
@@ -1009,8 +1014,8 @@ export const updateEventCommand = new Command('update-event')
                   } else {
                     console.log('\n\u2713 Event updated successfully.');
                     console.log(`\n  Title: ${ur.data.subject ?? ''}`);
-                    const st = ur.data.start?.dateTime ?? '';
-                    const en = ur.data.end?.dateTime ?? '';
+                    const st = graphStartDt(ur.data);
+                    const en = graphEndDt(ur.data);
                     if (st && en) {
                       console.log(`  When:  ${formatDate(st)} ${formatTime(st)} - ${formatTime(en)}`);
                     }

--- a/src/test/cli.integration.test.ts
+++ b/src/test/cli.integration.test.ts
@@ -1936,6 +1936,46 @@ describe('Graph backend (M365_EXCHANGE_BACKEND=graph)', () => {
     expect(result.stdout).toContain('Event updated successfully');
   });
 
+  test('update-event --all-day patches isAllDay via Graph (bug regression)', async () => {
+    let patchBody = '';
+    setMockFetch((url, request, body) => {
+      if (!url.includes('graph.microsoft.com/v1.0')) return null;
+      const method = (request?.method || 'GET').toUpperCase();
+      const path = new URL(url).pathname;
+      if (method === 'PATCH' && /^\/v1\.0\/me\/events\/[^/]+$/.test(path)) {
+        patchBody = body;
+        return {
+          status: 200,
+          body: JSON.stringify({ id: 'graph-cal-event-1', subject: 'Standup', changeKey: 'ck2' }),
+          contentType: 'application/json'
+        };
+      }
+      return null;
+    });
+    const result = await runM365AgentCli('update-event --id graph-cal-event-1 --all-day --token test-graph-token');
+    expect(result.exitCode).toBe(0);
+    expect(patchBody).not.toBe('');
+    const patch = JSON.parse(patchBody);
+    expect(patch.isAllDay).toBe(true);
+  });
+
+  test('update-event with no update flags shows the correct (normalized) time on a non-UTC host (bug regression)', async () => {
+    const originalTz = process.env.TZ;
+    try {
+      // The mock event is start=09:00/end=09:30 UTC (unzoned dateTime, timeZone:"UTC"). On a
+      // Europe/Berlin host (UTC+2 in April), the correct displayed times are 11:00-11:30 — a raw
+      // `new Date(unzoned string)` would misinterpret it as already-local and show 09:00-09:30.
+      process.env.TZ = 'Europe/Berlin';
+      const result = await runM365AgentCli('update-event --id graph-cal-event-1 --token test-graph-token');
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('11:00');
+      expect(result.stdout).not.toContain('09:00 - 09:30');
+    } finally {
+      if (originalTz === undefined) delete process.env.TZ;
+      else process.env.TZ = originalTz;
+    }
+  });
+
   test('mail --reply --bcc patches the reply draft with bccRecipients before sending', async () => {
     const patchBodies: string[] = [];
     let sendCalled = false;
@@ -2500,5 +2540,68 @@ describe('viva-tenant-subcommands --json error envelope (bug regression)', () =>
     expect(result.exitCode).toBe(1);
     expect(result.stdout).toBe('');
     expect(result.stderr).toContain('Access denied');
+  });
+});
+
+describe('suggest --days validation (bug regression)', () => {
+  test('--days -3 is rejected instead of silently producing an inverted date range', async () => {
+    const result = await runM365AgentCli('suggest --days -3 --json --token test-graph-token');
+    expect(result.exitCode).not.toBe(0);
+    const data = JSON.parse(result.stdout.trim());
+    expect(data.error.message).toContain('Invalid --days');
+  });
+
+  test('--days 0 is honored (not silently substituted with the default of 5)', async () => {
+    let requestBody = '';
+    setMockFetch((url, request, body) => {
+      if (!url.includes('graph.microsoft.com/v1.0') || !url.includes('findMeetingTimes')) return null;
+      requestBody = body;
+      return {
+        status: 200,
+        body: JSON.stringify({ meetingTimeSuggestions: [], emptySuggestionsReason: 'None' }),
+        contentType: 'application/json'
+      };
+    });
+    const result = await runM365AgentCli('suggest --days 0 --json --token test-graph-token');
+    expect(result.exitCode).toBe(0);
+    expect(requestBody).not.toBe('');
+    const req = JSON.parse(requestBody);
+    const start = new Date(req.timeConstraint.timeSlots[0].start.dateTime);
+    const end = new Date(req.timeConstraint.timeSlots[0].end.dateTime);
+    // With --days 0, the window should not span more than the same day (previously "0 || 5" silently
+    // widened this to a 5-day window).
+    expect(end.getTime() - start.getTime()).toBeLessThan(24 * 60 * 60 * 1000);
+  });
+});
+
+describe('oof fetch-failure guard (bug regression)', () => {
+  test('--internal-message aborts instead of silently disabling OOF when the pre-fetch fails', async () => {
+    let patchedStatus: string | undefined;
+    setMockFetch((url, request, body) => {
+      if (!url.includes('graph.microsoft.com/v1.0') || !url.includes('/mailboxSettings')) return null;
+      const method = (request?.method || 'GET').toUpperCase();
+      if (method === 'GET') {
+        // The pre-fetch (needed to preserve the existing OOF status/schedule before a partial
+        // --internal-message-only PATCH) fails here.
+        return {
+          status: 403,
+          body: JSON.stringify({ error: { code: 'ErrorAccessDenied', message: 'Access denied' } }),
+          contentType: 'application/json'
+        };
+      }
+      // The PATCH itself would succeed if the command incorrectly proceeded anyway — capturing the
+      // status sent lets the test distinguish "aborted before PATCH" from "PATCH sent status:disabled".
+      try {
+        patchedStatus = JSON.parse(body)?.automaticRepliesSetting?.status;
+      } catch {
+        // ignore
+      }
+      return { status: 200, body: JSON.stringify({}), contentType: 'application/json' };
+    });
+    const result = await runM365AgentCli('oof --internal-message "back soon" --json --token test-graph-token');
+    expect(result.exitCode).not.toBe(0);
+    expect(patchedStatus).toBeUndefined();
+    const data = JSON.parse(result.stdout.trim());
+    expect(data.error).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

Follow-up QA-review fixes found after the previous roadmap PR (#237) was merged — this branch was restarted from `main`'s current tip since #237 was already squash-merged.

- **`update-event.ts` (Graph path)**: a prior edit in this session accidentally dropped `allDay: options.allDay` from the `buildGraphUpdatePatch()` call, so `--all-day`/`--no-all-day` was silently ignored (or, if it was the only flag given, produced a spurious "No field updates to apply" error) when updating an event via Graph.
- **`update-event.ts` / `delete-event.ts`**: several display and JSON-output call sites still read Graph's zone-less `start`/`end` `dateTime` raw instead of going through `normalizeGraphDateTimeForParsing`, showing the wrong time on non-UTC hosts. Added a `graphEndDt()` helper alongside the existing `graphStartDt()` and routed every remaining call site through both.
- **`oof.ts`**: updating only `--internal-message`/`--external-message` (no `--status`) fetches the current OOF settings to preserve them across a partial PATCH; if that fetch failed for any reason, the code silently defaulted to `status: 'disabled'`, which could turn off a live out-of-office reply as a side effect of an unrelated message-text edit. It now aborts with an error when the fetch itself fails, instead of guessing.
- **`suggest.ts`**: `parseInt(options.days, 10) || 5` treated an explicit `--days 0` as falsy and silently substituted 5, and never rejected negative values (which would send Graph an inverted time window). Now validates `--days` is a non-negative integer.

## Test plan

- [x] `bun run typecheck`
- [x] `bunx biome check --write` on touched files
- [x] `bun test` (860 pass, 0 fail)
- [x] `bun run knip`
- [x] `bun run graph:inventory` + `:check`
- [x] `bun run docs:graph-permission-matrix:check`
- [x] `bun run verify:cli-help-examples`
- [x] `COVERAGE_MIN_LINES_LIB=50 bun run verify:coverage:lib`
- [x] Each fix has a regression test that was verified to fail against the reverted (buggy) code before being confirmed against the fix


---
_Generated by [Claude Code](https://claude.ai/code/session_01APKpRDq8wfR9BDihxxRUWd)_